### PR TITLE
chore: Fix snapshot updater

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -1,4 +1,4 @@
-name: update snapshot
+name: update-snapshot
 
 on:
   workflow_run:
@@ -24,7 +24,7 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Snapshot main
         run: |
-          npm run compile
+          npm run bundle
           npm run integ:default:snapshot
       - name: Switch to branch
         run: git checkout ${{ github.event.workflow_run.head_branch }}
@@ -32,7 +32,7 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Snapshot branch
         run: |
-          npm run compile
+          npm run bundle
           npm run integ:default:snapshot
       - name: Find mutations
         id: create_patch


### PR DESCRIPTION
We need `npm run bundle` not `npm run compile`