### PR TITLE
chore: Fix snapshot updating

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -52,6 +52,9 @@
           "spawn": "bundle:package-nodejs.lambda"
         },
         {
+          "exec": "rm -rf assets/package-ruby.lambda"
+        },
+        {
           "exec": "mkdir -p assets/package-python.lambda assets/package-ruby.lambda"
         },
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -102,6 +102,7 @@ project.gitattributes.addAttributes('*.yml', 'eol=lf');
 project.gitattributes.addAttributes('Dockerfile', 'eol=lf');
 
 // extra lambdas
+project.bundler.bundleTask.exec('rm -rf assets/package-ruby.lambda');
 project.bundler.bundleTask.exec('mkdir -p assets/package-python.lambda assets/package-ruby.lambda');
 project.bundler.bundleTask.exec('cp src/package-python.lambda.py assets/package-python.lambda/index.py');
 project.bundler.bundleTask.exec('cp src/package-ruby.lambda.rb assets/package-ruby.lambda/index.rb');


### PR DESCRIPTION
If assets folder is left behind, our mv command puts the library folder inside rubzip instead of replacing it