### PR TITLE
fix: CodeBuild packaging errors were ignored

### DIFF
--- a/src/package-codebuild.lambda.ts
+++ b/src/package-codebuild.lambda.ts
@@ -124,8 +124,8 @@ fi`];
 /**
  * Convert commands to a command that logs everything into /tmp/codebuild.log.
  *
- * @return ( set -ex; command-1 ; command 2 ;  ) 2>&1 | tee /tmp/codebuild.log
+ * @return set -o pipefail ; ( set -ex; command-1 ; command 2 ;  ) 2>&1 | tee /tmp/codebuild.log
  */
 function logCommands(commands: string[]): string[] {
-  return [['( set -ex'].concat(commands).concat([' ) 2>&1 | tee /tmp/codebuild.log']).join(' ; ')];
+  return [['set -o pipefail ; ( set -ex'].concat(commands).concat([' ) 2>&1 | tee /tmp/codebuild.log']).join(' ; ')];
 }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -14,15 +14,15 @@
         }
       }
     },
-    "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373": {
+    "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29": {
       "source": {
-        "path": "asset.79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.lambda",
+        "path": "asset.fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip",
+          "objectKey": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "40623564f27fda5c0ef73a491210cbd95d82c53b941e4ab862132382b54019c3": {
+    "39ca7cf8b80801bcf91395507b8225d5cab135ae5534b1a6eb0aa1b9329a28ff": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "40623564f27fda5c0ef73a491210cbd95d82c53b941e4ab862132382b54019c3.json",
+          "objectKey": "39ca7cf8b80801bcf91395507b8225d5cab135ae5534b1a6eb0aa1b9329a28ff.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -451,7 +451,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+     "S3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -3077,7 +3077,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+     "S3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -4814,7 +4814,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+     "S3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -5928,7 +5928,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+     "S3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/40623564f27fda5c0ef73a491210cbd95d82c53b941e4ab862132382b54019c3.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/39ca7cf8b80801bcf91395507b8225d5cab135ae5534b1a6eb0aa1b9329a28ff.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -645,7 +645,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+                              "s3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -4090,7 +4090,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+                              "s3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -6801,7 +6801,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+                              "s3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -8509,7 +8509,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "79df0a3b8f7c419b52052da8bd18d652d88f8f84375f3e38b59f0407ab4c3373.zip"
+                              "s3Key": "fadff72bb4ae801daf86aa127f9707e0363ef1be545539f523ea99dd1a90bd29.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [


### PR DESCRIPTION
The pipe to tee made all errors in the anonymous function get ignored. Use `set -o pipefail` to force failure even with the pipe.