### PR TITLE
fix: Typo in Python import name

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -24,7 +24,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   releaseToNpm: true,
   publishToPypi: {
     distName: 'cloudsnorkel.cdk-turbo-layers',
-    module: 'cloudsnorkel.cdk_turbo-layers',
+    module: 'cloudsnorkel.cdk_turbo_layers',
   },
   publishToGo: {
     moduleName: 'github.com/CloudSnorkel/cdk-turbo-layers-go',

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
       },
       "python": {
         "distName": "cloudsnorkel.cdk-turbo-layers",
-        "module": "cloudsnorkel.cdk_turbo-layers"
+        "module": "cloudsnorkel.cdk_turbo_layers"
       },
       "dotnet": {
         "namespace": "CloudSnorkel",


### PR DESCRIPTION
Import name was supposed to be `cloudsnorkel.cdk_turbo_layers` and not `cloudsnorkel.cdk_turbo-layers` which is very hard to import.

Fix #22