### PR TITLE
fix: Use correct runtime versions for Lambda packagers

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -202,6 +202,7 @@ export class BaseDependencyPackager extends Construct implements iam.IGrantable,
     } else if (this.type == DependencyPackagerType.LAMBDA) {
       const lambdaProps = {
         description: `Turbo layer packager for ${runtime}`,
+        runtime: runtime,
         timeout: Duration.minutes(15),
         memorySize: 1024,
         ephemeralStorageSize: Size.gibibytes(10),

--- a/src/base.ts
+++ b/src/base.ts
@@ -217,6 +217,11 @@ export class BaseDependencyPackager extends Construct implements iam.IGrantable,
         this.provider = new PackagePythonFunction(this, 'Packager', lambdaProps);
       } else if (runtime.family == lambda.RuntimeFamily.NODEJS) {
         this.provider = new PackageNodejsFunction(this, 'Packager', lambdaProps);
+        // we can't set the runtime from here, so we have to manually override it.
+        // projen puts `...props` before its own `runtime` setting and so its default `runtime` always wins.
+        // https://github.com/projen/projen/blob/564341a55309e06939c86248bc76cabc590fd835/src/awscdk/lambda-function.ts#L253-L256
+        const func = this.provider.node.defaultChild as lambda.CfnFunction;
+        func.runtime = runtime.name;
       } else if (runtime.family == lambda.RuntimeFamily.RUBY) {
         this.provider = new PackageRubyFunction(this, 'Packager', lambdaProps);
       } else {

--- a/src/package-nodejs-function.ts
+++ b/src/package-nodejs-function.ts
@@ -16,8 +16,8 @@ export class PackageNodejsFunction extends lambda.Function {
   constructor(scope: Construct, id: string, props?: PackageNodejsFunctionProps) {
     super(scope, id, {
       description: 'src/package-nodejs.lambda.ts',
-      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       ...props,
+      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/package-nodejs.lambda')),
     });

--- a/src/package-nodejs-function.ts
+++ b/src/package-nodejs-function.ts
@@ -16,8 +16,8 @@ export class PackageNodejsFunction extends lambda.Function {
   constructor(scope: Construct, id: string, props?: PackageNodejsFunctionProps) {
     super(scope, id, {
       description: 'src/package-nodejs.lambda.ts',
-      ...props,
       runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
+      ...props,
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/package-nodejs.lambda')),
     });

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "db7d3b44e017b63db50197704b29eb97bac168a71ac559a53b3bf68db6f123aa": {
+    "fe6521518edb0de46de9d099e5e747350e8a6dab27f5cc38112716d0a7f6b9b0": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "db7d3b44e017b63db50197704b29eb97bac168a71ac559a53b3bf68db6f123aa.json",
+          "objectKey": "fe6521518edb0de46de9d099e5e747350e8a6dab27f5cc38112716d0a7f6b9b0.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -3866,7 +3866,7 @@
     },
     "Handler": "index.handler",
     "MemorySize": 1024,
-    "Runtime": "nodejs14.x",
+    "Runtime": "nodejs16.x",
     "Timeout": 900
    },
    "DependsOn": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/db7d3b44e017b63db50197704b29eb97bac168a71ac559a53b3bf68db6f123aa.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/fe6521518edb0de46de9d099e5e747350e8a6dab27f5cc38112716d0a7f6b9b0.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -5319,7 +5319,7 @@
                             },
                             "handler": "index.handler",
                             "memorySize": 1024,
-                            "runtime": "nodejs14.x",
+                            "runtime": "nodejs16.x",
                             "timeout": 900
                           }
                         },

--- a/test/nodejs.test.ts
+++ b/test/nodejs.test.ts
@@ -1,4 +1,7 @@
-import { librariesToPackageJson } from '../src';
+import * as cdk from 'aws-cdk-lib';
+import { aws_lambda as lambda } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { librariesToPackageJson, NodejsDependencyPackager } from '../src';
 
 test('Inline version parsing', () => {
   const packageJson = librariesToPackageJson(['@aws-sdk/client-s3@3.259.0', 'nothing', 'library@v595']);
@@ -10,3 +13,40 @@ test('Inline version parsing', () => {
     },
   });
 });
+
+test('Packager runtime version matches', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'test');
+
+  new NodejsDependencyPackager(stack, 'packager 14', {
+    runtime: lambda.Runtime.NODEJS_14_X,
+  });
+  new NodejsDependencyPackager(stack, 'packager 16', {
+    runtime: lambda.Runtime.NODEJS_16_X,
+  });
+  new NodejsDependencyPackager(stack, 'packager 18', {
+    runtime: lambda.Runtime.NODEJS_18_X,
+  });
+
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties(
+    'AWS::Lambda::Function',
+    Match.objectLike({
+      Runtime: lambda.Runtime.NODEJS_14_X.name,
+    }),
+  );
+  template.hasResourceProperties(
+    'AWS::Lambda::Function',
+    Match.objectLike({
+      Runtime: lambda.Runtime.NODEJS_16_X.name,
+    }),
+  );
+  template.hasResourceProperties(
+    'AWS::Lambda::Function',
+    Match.objectLike({
+      Runtime: lambda.Runtime.NODEJS_18_X.name,
+    }),
+  );
+});
+

--- a/test/python.test.ts
+++ b/test/python.test.ts
@@ -1,0 +1,40 @@
+import * as cdk from 'aws-cdk-lib';
+import { aws_lambda as lambda } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { PythonDependencyPackager } from '../src';
+
+test('Packager runtime version matches', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'test');
+
+  new PythonDependencyPackager(stack, 'packager 3.7', {
+    runtime: lambda.Runtime.PYTHON_3_7,
+  });
+  new PythonDependencyPackager(stack, 'packager 3.8', {
+    runtime: lambda.Runtime.PYTHON_3_8,
+  });
+  new PythonDependencyPackager(stack, 'packager 3.9', {
+    runtime: lambda.Runtime.PYTHON_3_9,
+  });
+
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties(
+    'AWS::Lambda::Function',
+    Match.objectLike({
+      Runtime: lambda.Runtime.PYTHON_3_7.name,
+    }),
+  );
+  template.hasResourceProperties(
+    'AWS::Lambda::Function',
+    Match.objectLike({
+      Runtime: lambda.Runtime.PYTHON_3_8.name,
+    }),
+  );
+  template.hasResourceProperties(
+    'AWS::Lambda::Function',
+    Match.objectLike({
+      Runtime: lambda.Runtime.PYTHON_3_9.name,
+    }),
+  );
+});


### PR DESCRIPTION
The default runtime version was always used in the Lambda packager. This caused the wrong versions of Python libraries to be installed.