### PR TITLE
fix: Node.js 18.x support

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -149,7 +149,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.77.0",
+      "version": "^2.87.0",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -5,7 +5,11 @@
       "type": "build"
     },
     {
-      "name": "@aws-sdk/types",
+      "name": "@aws-sdk/client-codebuild",
+      "type": "build"
+    },
+    {
+      "name": "@aws-sdk/client-s3",
       "type": "build"
     },
     {
@@ -43,10 +47,6 @@
     {
       "name": "aws-cdk",
       "version": "^2",
-      "type": "build"
-    },
-    {
-      "name": "aws-sdk",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -87,7 +87,7 @@
       "description": "Create a JavaScript bundle from src/package-codebuild.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-codebuild.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-codebuild.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:@aws-sdk/*"
+          "exec": "esbuild --bundle src/package-codebuild.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-codebuild.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -96,7 +96,7 @@
       "description": "Continuously update the JavaScript bundle from src/package-codebuild.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-codebuild.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-codebuild.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:@aws-sdk/* --watch"
+          "exec": "esbuild --bundle src/package-codebuild.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-codebuild.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },
@@ -105,7 +105,7 @@
       "description": "Create a JavaScript bundle from src/package-nodejs.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-nodejs.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-nodejs.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:@aws-sdk/*"
+          "exec": "esbuild --bundle src/package-nodejs.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-nodejs.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -114,7 +114,7 @@
       "description": "Continuously update the JavaScript bundle from src/package-nodejs.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/package-nodejs.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-nodejs.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:@aws-sdk/* --watch"
+          "exec": "esbuild --bundle src/package-nodejs.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/package-nodejs.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },
@@ -470,13 +470,13 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-lambda-python-alpha,@aws-sdk/types,@types/adm-zip,@types/aws-lambda,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,adm-zip,aws-cdk,aws-sdk,esbuild,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint,execa,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript,xterm-benchmark,aws-cdk-lib,constructs"
+          "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-lambda-python-alpha,@aws-sdk/client-codebuild,@aws-sdk/client-s3,@types/adm-zip,@types/aws-lambda,@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,adm-zip,aws-cdk,esbuild,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint,execa,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,projen,standard-version,ts-jest,ts-node,typescript,xterm-benchmark,aws-cdk-lib,constructs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-cdk/aws-lambda-python-alpha @aws-sdk/types @types/adm-zip @types/aws-lambda @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser adm-zip aws-cdk aws-sdk esbuild eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint execa jest-junit jest jsii-diff jsii-docgen jsii-pacmak npm-check-updates projen standard-version ts-jest ts-node typescript xterm-benchmark aws-cdk-lib constructs"
+          "exec": "yarn upgrade @aws-cdk/aws-lambda-python-alpha @aws-sdk/client-codebuild @aws-sdk/client-s3 @types/adm-zip @types/aws-lambda @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser adm-zip aws-cdk esbuild eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint execa jest-junit jest jsii-diff jsii-docgen jsii-pacmak npm-check-updates projen standard-version ts-jest ts-node typescript xterm-benchmark aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -6,7 +6,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Amir Szekely',
   authorAddress: 'amir@cloudsnorkel.com',
   stability: Stability.EXPERIMENTAL,
-  cdkVersion: '2.77.0', // 2.54.0 for https://github.com/aws/aws-cdk/pull/22124, 2.77.0 for removing node 14
+  cdkVersion: '2.87.0', // 2.54.0 for https://github.com/aws/aws-cdk/pull/22124, 2.77.0 for removing node 14, 2.87.0 for node 18 on CodeBuild
   defaultReleaseBranch: 'main',
   name: '@cloudsnorkel/cdk-turbo-layers',
   repositoryUrl: 'https://github.com/CloudSnorkel/cdk-turbo-layers.git',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -14,8 +14,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
   description: 'Speed-up Lambda function deployment with dependency layers built in AWS',
   devDeps: [
     'esbuild', // for faster NodejsFunction bundling
-    'aws-sdk',
-    '@aws-sdk/types',
+    '@aws-sdk/client-codebuild',
+    '@aws-sdk/client-s3',
     '@types/aws-lambda',
     'adm-zip',
     '@types/adm-zip',
@@ -100,6 +100,13 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   tsconfig: {
     include: ['benchmark/**/*.ts'],
+  },
+  lambdaOptions: {
+    bundlingOptions: {
+      // we can't count on @aws-sdk to be there because the user might use nodejs 16 or 18
+      // this will cause @aws-sdk to be bundled in our lambda
+      externals: [],
+    },
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   },
   "devDependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "^2.101.0-alpha.0",
-    "@aws-sdk/types": "^3.428.0",
+    "@aws-sdk/client-codebuild": "^3.428.0",
+    "@aws-sdk/client-s3": "^3.428.0",
     "@types/adm-zip": "^0.5.2",
     "@types/aws-lambda": "^8.10.124",
     "@types/jest": "^27",
@@ -62,7 +63,6 @@
     "adm-zip": "^0.5.10",
     "aws-cdk": "^2",
     "aws-cdk-lib": "2.77.0",
-    "aws-sdk": "^2.1473.0",
     "constructs": "10.0.5",
     "esbuild": "^0.19.4",
     "eslint": "^8",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/parser": "^6",
     "adm-zip": "^0.5.10",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.77.0",
+    "aws-cdk-lib": "2.87.0",
     "constructs": "10.0.5",
     "esbuild": "^0.19.4",
     "eslint": "^8",
@@ -86,7 +86,7 @@
     "xterm-benchmark": "^0.3.1"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.77.0",
+    "aws-cdk-lib": "^2.87.0",
     "constructs": "^10.0.5"
   },
   "resolutions": {

--- a/src/base.ts
+++ b/src/base.ts
@@ -164,7 +164,7 @@ export class BaseDependencyPackager extends Construct implements iam.IGrantable,
         subnetSelection: internalProps.props?.subnetSelection,
         environment: {
           buildImage: this.architecture == lambda.Architecture.X86_64 ?
-            codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 : codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_2_0,
+            codebuild.LinuxBuildImage.AMAZON_LINUX_2_5 : codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_2_0,
         },
         logging: {
           cloudWatch: {

--- a/src/package-codebuild.lambda.ts
+++ b/src/package-codebuild.lambda.ts
@@ -1,11 +1,11 @@
 /* eslint-disable-next-line import/no-extraneous-dependencies,import/no-unresolved */
+import { CodeBuildClient, StartBuildCommand } from '@aws-sdk/client-codebuild';
+import { DeleteObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import * as AWSLambda from 'aws-lambda';
-/* eslint-disable-next-line import/no-extraneous-dependencies */
-import * as AWS from 'aws-sdk';
 import { customResourceRespond } from './cr';
 
-const codebuild = new AWS.CodeBuild();
-const s3 = new AWS.S3();
+const codebuild = new CodeBuildClient();
+const s3 = new S3Client();
 
 
 /* eslint-disable @typescript-eslint/no-require-imports, import/no-extraneous-dependencies */
@@ -43,7 +43,7 @@ fi`];
       case 'Create':
       case 'Update':
         console.log(`Starting CodeBuild project ${projectName}`);
-        await codebuild.startBuild({
+        await codebuild.send(new StartBuildCommand({
           projectName,
           sourceTypeOverride: 'S3',
           sourceLocationOverride: `${assetBucket}/${assetKey}`,
@@ -101,14 +101,14 @@ fi`];
               },
             },
           }, null, 2),
-        }).promise();
+        }));
         break;
       case 'Delete':
         try {
-          await s3.deleteObject({
+          await s3.send(new DeleteObjectCommand({
             Bucket: targetBucket,
             Key: event.PhysicalResourceId,
-          }).promise();
+          }));
         } catch (e) {
           console.error(`Ignoring error to delete s3://${targetBucket}/${event.PhysicalResourceId}`);
         }

--- a/src/package-nodejs.lambda.ts
+++ b/src/package-nodejs.lambda.ts
@@ -1,14 +1,13 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import * as AWSLambda from 'aws-lambda';
-/* eslint-disable-next-line import/no-extraneous-dependencies */
-import * as AWS from 'aws-sdk';
 import { customResourceRespond } from './cr';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const AdmZip = require('adm-zip');
 
-const s3 = new AWS.S3();
+const s3 = new S3Client();
 
 
 /* eslint-disable @typescript-eslint/no-require-imports, import/no-extraneous-dependencies */
@@ -29,7 +28,7 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
     // setup home
     try {
       fs.mkdirSync('/tmp/home');
-    } catch (err) {
+    } catch (err: any) {
       if (err.code !== 'EEXIST') {
         throw err;
       }
@@ -56,10 +55,10 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
         break;
       case 'Delete':
         try {
-          await s3.deleteObject({
+          await s3.send(new DeleteObjectCommand({
             Bucket: targetBucket,
             Key: event.PhysicalResourceId,
-          }).promise();
+          }));
         } catch (error) {
           console.error(`Ignoring error to delete s3://${targetBucket}/${event.PhysicalResourceId}`);
         }
@@ -78,15 +77,15 @@ async function install(assetBucket: string, assetKey: string, commands: string[]
     // extract asset with package.json file
     console.log('Downloading and unpacking asset...');
 
-    const assetObject = await s3.getObject({
+    const assetObject = await s3.send(new GetObjectCommand({
       Bucket: assetBucket,
       Key: assetKey,
-    }).promise();
+    }));
     if (!assetObject.Body) {
       throw new Error('Unable to read asset');
     }
 
-    new AdmZip(assetObject.Body as Buffer).extractAllTo(temp);
+    new AdmZip(Buffer.from(await assetObject.Body.transformToByteArray())).extractAllTo(temp);
 
     // run installation commands
     console.log('Running installation commands...');
@@ -127,11 +126,11 @@ async function install(assetBucket: string, assetKey: string, commands: string[]
 
     // upload package
     console.log('Uploading package...');
-    await s3.upload({
+    await s3.send(new PutObjectCommand({
       Bucket: targetBucket,
       Key: `${zipHash}.zip`,
       Body: fs.createReadStream(zipPath),
-    }).promise();
+    }));
 
     return `${zipHash}.zip`;
   } finally {

--- a/src/package-nodejs.lambda.ts
+++ b/src/package-nodejs.lambda.ts
@@ -28,7 +28,8 @@ export async function handler(event: AWSLambda.CloudFormationCustomResourceEvent
     // setup home
     try {
       fs.mkdirSync('/tmp/home');
-    } catch (err: any) {
+    } catch (err) {
+      // @ts-ignore
       if (err.code !== 'EEXIST') {
         throw err;
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -1,15 +1,15 @@
 {
-  "version": "31.0.0",
+  "version": "32.0.0",
   "files": {
-    "40aa87cdf43c4095cec18bc443965f22ab2f8c1ace47e482a0ba4e35d83b0cc9": {
+    "d28a3fa64d0bd6c7c6f1d6fd707d3e6dc5c81fe8f47891b89459b6492586997f": {
       "source": {
-        "path": "asset.40aa87cdf43c4095cec18bc443965f22ab2f8c1ace47e482a0ba4e35d83b0cc9",
+        "path": "asset.d28a3fa64d0bd6c7c6f1d6fd707d3e6dc5c81fe8f47891b89459b6492586997f",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "40aa87cdf43c4095cec18bc443965f22ab2f8c1ace47e482a0ba4e35d83b0cc9.zip",
+          "objectKey": "d28a3fa64d0bd6c7c6f1d6fd707d3e6dc5c81fe8f47891b89459b6492586997f.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,15 +27,15 @@
         }
       }
     },
-    "f5b6a6d08a8206e67d0b54e2a29abd7e0472d835abc71037de3a93545b5edacc": {
+    "5fa1330271b8967d9254ba2d4a07144f8acefe8b77e6d6bba38261373a50d5f8": {
       "source": {
-        "path": "asset.f5b6a6d08a8206e67d0b54e2a29abd7e0472d835abc71037de3a93545b5edacc",
+        "path": "asset.5fa1330271b8967d9254ba2d4a07144f8acefe8b77e6d6bba38261373a50d5f8",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f5b6a6d08a8206e67d0b54e2a29abd7e0472d835abc71037de3a93545b5edacc.zip",
+          "objectKey": "5fa1330271b8967d9254ba2d4a07144f8acefe8b77e6d6bba38261373a50d5f8.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -53,15 +53,15 @@
         }
       }
     },
-    "e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d": {
+    "61b977bd2ad84e98e78440b618c2decfff23ec89f32908ad25d182c090bf6bec": {
       "source": {
-        "path": "asset.e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d",
+        "path": "asset.61b977bd2ad84e98e78440b618c2decfff23ec89f32908ad25d182c090bf6bec",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d.zip",
+          "objectKey": "61b977bd2ad84e98e78440b618c2decfff23ec89f32908ad25d182c090bf6bec.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "12fc37fe63c4e8c1cd414d9f88013e6fb727d50abee15fed3294a634b955ce38": {
+    "3a503d4db4e69346c332bfe77fce8ce0c794379d3af40b21131b92e270d6c489": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "12fc37fe63c4e8c1cd414d9f88013e6fb727d50abee15fed3294a634b955ce38.json",
+          "objectKey": "3a503d4db4e69346c332bfe77fce8ce0c794379d3af40b21131b92e270d6c489.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -14,15 +14,15 @@
         }
       }
     },
-    "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083": {
+    "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102": {
       "source": {
-        "path": "asset.611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.lambda",
+        "path": "asset.4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip",
+          "objectKey": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -157,15 +157,15 @@
         }
       }
     },
-    "75f547f8ec7caf5df0eae3fb02f0336444654208d287492b50cfe563b46b9588": {
+    "d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5": {
       "source": {
-        "path": "asset.75f547f8ec7caf5df0eae3fb02f0336444654208d287492b50cfe563b46b9588.lambda",
+        "path": "asset.d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "75f547f8ec7caf5df0eae3fb02f0336444654208d287492b50cfe563b46b9588.zip",
+          "objectKey": "d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "70e2efee6f5ed2f653455df94122c9a80e1f3c3fcfbc96517e2bf4476741499d": {
+    "12fc37fe63c4e8c1cd414d9f88013e6fb727d50abee15fed3294a634b955ce38": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "70e2efee6f5ed2f653455df94122c9a80e1f3c3fcfbc96517e2bf4476741499d.json",
+          "objectKey": "12fc37fe63c4e8c1cd414d9f88013e6fb727d50abee15fed3294a634b955ce38.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -329,7 +329,7 @@
     },
     "Environment": {
      "ComputeType": "BUILD_GENERAL1_SMALL",
-     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
      "ImagePullCredentialsType": "CODEBUILD",
      "PrivilegedMode": false,
      "Type": "LINUX_CONTAINER"
@@ -1192,18 +1192,18 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "40aa87cdf43c4095cec18bc443965f22ab2f8c1ace47e482a0ba4e35d83b0cc9.zip"
+     "S3Key": "d28a3fa64d0bd6c7c6f1d6fd707d3e6dc5c81fe8f47891b89459b6492586997f.zip"
     },
     "Timeout": 900,
     "MemorySize": 128,
-    "Handler": "__entrypoint__.handler",
+    "Handler": "index.handler",
     "Role": {
      "Fn::GetAtt": [
       "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
       "Arn"
      ]
     },
-    "Runtime": "nodejs16.x",
+    "Runtime": "nodejs18.x",
     "Description": {
      "Fn::Join": [
       "",
@@ -1293,7 +1293,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "f5b6a6d08a8206e67d0b54e2a29abd7e0472d835abc71037de3a93545b5edacc.zip"
+     "S3Key": "5fa1330271b8967d9254ba2d4a07144f8acefe8b77e6d6bba38261373a50d5f8.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -1852,7 +1852,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "e6b302aaee9bb5261338cf6b21e540e805eeaf2c18eb3246f7556104f361f68d.zip"
+     "S3Key": "61b977bd2ad84e98e78440b618c2decfff23ec89f32908ad25d182c090bf6bec.zip"
     },
     "Timeout": 900,
     "MemorySize": 128,
@@ -1863,7 +1863,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs16.x"
+    "Runtime": "nodejs18.x"
    },
    "DependsOn": [
     "AWSCDKTriggerCustomResourceProviderCustomResourceProviderRoleE18FAF0A"
@@ -3111,7 +3111,7 @@
     },
     "Environment": {
      "ComputeType": "BUILD_GENERAL1_SMALL",
-     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
      "ImagePullCredentialsType": "CODEBUILD",
      "PrivilegedMode": false,
      "Type": "LINUX_CONTAINER"
@@ -4860,7 +4860,7 @@
     },
     "Environment": {
      "ComputeType": "BUILD_GENERAL1_SMALL",
-     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
      "ImagePullCredentialsType": "CODEBUILD",
      "PrivilegedMode": false,
      "Type": "LINUX_CONTAINER"
@@ -6609,7 +6609,7 @@
     },
     "Environment": {
      "ComputeType": "BUILD_GENERAL1_SMALL",
-     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
      "ImagePullCredentialsType": "CODEBUILD",
      "PrivilegedMode": false,
      "Type": "LINUX_CONTAINER"
@@ -7727,7 +7727,7 @@
     },
     "Environment": {
      "ComputeType": "BUILD_GENERAL1_SMALL",
-     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
      "ImagePullCredentialsType": "CODEBUILD",
      "PrivilegedMode": false,
      "Type": "LINUX_CONTAINER"

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -451,7 +451,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+     "S3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -1632,6 +1632,138 @@
              {
               "Fn::GetAtt": [
                "Nodejs16LambdaYarnTest8F96551D",
+               "Arn"
+              ]
+             },
+             ":*"
+            ]
+           ]
+          }
+         ]
+        },
+        {
+         "Effect": "Allow",
+         "Action": [
+          "lambda:InvokeFunction"
+         ],
+         "Resource": [
+          {
+           "Fn::Join": [
+            "",
+            [
+             {
+              "Fn::GetAtt": [
+               "Nodejs18CodeBuildNPMInlineTest2E004270",
+               "Arn"
+              ]
+             },
+             ":*"
+            ]
+           ]
+          }
+         ]
+        },
+        {
+         "Effect": "Allow",
+         "Action": [
+          "lambda:InvokeFunction"
+         ],
+         "Resource": [
+          {
+           "Fn::Join": [
+            "",
+            [
+             {
+              "Fn::GetAtt": [
+               "Nodejs18CodeBuildNPMTest4642EE2D",
+               "Arn"
+              ]
+             },
+             ":*"
+            ]
+           ]
+          }
+         ]
+        },
+        {
+         "Effect": "Allow",
+         "Action": [
+          "lambda:InvokeFunction"
+         ],
+         "Resource": [
+          {
+           "Fn::Join": [
+            "",
+            [
+             {
+              "Fn::GetAtt": [
+               "Nodejs18CodeBuildYarnTest4486EC0A",
+               "Arn"
+              ]
+             },
+             ":*"
+            ]
+           ]
+          }
+         ]
+        },
+        {
+         "Effect": "Allow",
+         "Action": [
+          "lambda:InvokeFunction"
+         ],
+         "Resource": [
+          {
+           "Fn::Join": [
+            "",
+            [
+             {
+              "Fn::GetAtt": [
+               "Nodejs18LambdaNPMInlineTest3C9BC6C6",
+               "Arn"
+              ]
+             },
+             ":*"
+            ]
+           ]
+          }
+         ]
+        },
+        {
+         "Effect": "Allow",
+         "Action": [
+          "lambda:InvokeFunction"
+         ],
+         "Resource": [
+          {
+           "Fn::Join": [
+            "",
+            [
+             {
+              "Fn::GetAtt": [
+               "Nodejs18LambdaNPMTest880421DA",
+               "Arn"
+              ]
+             },
+             ":*"
+            ]
+           ]
+          }
+         ]
+        },
+        {
+         "Effect": "Allow",
+         "Action": [
+          "lambda:InvokeFunction"
+         ],
+         "Resource": [
+          {
+           "Fn::Join": [
+            "",
+            [
+             {
+              "Fn::GetAtt": [
+               "Nodejs18LambdaYarnTestAE6021EA",
                "Arn"
               ]
              },
@@ -3101,7 +3233,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+     "S3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -3874,7 +4006,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "75f547f8ec7caf5df0eae3fb02f0336444654208d287492b50cfe563b46b9588.zip"
+     "S3Key": "d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -4399,6 +4531,1755 @@
     }
    }
   },
+  "Nodejs18CodeBuildPackagerBucket79764435": {
+   "Type": "AWS::S3::Bucket",
+   "Properties": {
+    "Tags": [
+     {
+      "Key": "aws-cdk:auto-delete-objects",
+      "Value": "true"
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildPackagerBucketPolicy1FFB1A92": {
+   "Type": "AWS::S3::BucketPolicy",
+   "Properties": {
+    "Bucket": {
+     "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+    },
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "s3:GetBucket*",
+        "s3:List*",
+        "s3:DeleteObject*"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "AWS": {
+         "Fn::GetAtt": [
+          "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+          "Arn"
+         ]
+        }
+       },
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "Nodejs18CodeBuildPackagerBucket79764435",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "Nodejs18CodeBuildPackagerBucket79764435",
+             "Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "Nodejs18CodeBuildPackagerBucketAutoDeleteObjectsCustomResourceF163B54A": {
+   "Type": "Custom::S3AutoDeleteObjects",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "Arn"
+     ]
+    },
+    "BucketName": {
+     "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+    }
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackagerBucketPolicy1FFB1A92"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildPackagerLogsE4807E34": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 30
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildPackagerRole6D628672": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "codebuild.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "Nodejs18CodeBuildPackagerLogsE4807E34",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":logs:",
+           {
+            "Ref": "AWS::Region"
+           },
+           ":",
+           {
+            "Ref": "AWS::AccountId"
+           },
+           ":log-group:/aws/codebuild/",
+           {
+            "Ref": "Nodejs18CodeBuildPackager634BA08F"
+           }
+          ]
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":logs:",
+           {
+            "Ref": "AWS::Region"
+           },
+           ":",
+           {
+            "Ref": "AWS::AccountId"
+           },
+           ":log-group:/aws/codebuild/",
+           {
+            "Ref": "Nodejs18CodeBuildPackager634BA08F"
+           },
+           ":*"
+          ]
+         ]
+        }
+       ]
+      },
+      {
+       "Action": [
+        "codebuild:CreateReportGroup",
+        "codebuild:CreateReport",
+        "codebuild:UpdateReport",
+        "codebuild:BatchPutTestCases",
+        "codebuild:BatchPutCodeCoverages"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":codebuild:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":report-group/",
+          {
+           "Ref": "Nodejs18CodeBuildPackager634BA08F"
+          },
+          "-*"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "s3:DeleteObject*",
+        "s3:PutObject",
+        "s3:PutObjectLegalHold",
+        "s3:PutObjectRetention",
+        "s3:PutObjectTagging",
+        "s3:PutObjectVersionTagging",
+        "s3:Abort*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "Nodejs18CodeBuildPackagerBucket79764435",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "Nodejs18CodeBuildPackagerBucket79764435",
+             "Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      },
+      {
+       "Action": "s3:DeleteObject*",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Fn::GetAtt": [
+            "Nodejs18CodeBuildPackagerBucket79764435",
+            "Arn"
+           ]
+          },
+          "/*"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "s3:GetObject*",
+        "s3:GetBucket*",
+        "s3:List*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+           }
+          ]
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Roles": [
+     {
+      "Ref": "Nodejs18CodeBuildPackagerRole6D628672"
+     }
+    ]
+   }
+  },
+  "Nodejs18CodeBuildPackager634BA08F": {
+   "Type": "AWS::CodeBuild::Project",
+   "Properties": {
+    "Artifacts": {
+     "Type": "NO_ARTIFACTS"
+    },
+    "Environment": {
+     "ComputeType": "BUILD_GENERAL1_SMALL",
+     "Image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+     "ImagePullCredentialsType": "CODEBUILD",
+     "PrivilegedMode": false,
+     "Type": "LINUX_CONTAINER"
+    },
+    "ServiceRole": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildPackagerRole6D628672",
+      "Arn"
+     ]
+    },
+    "Source": {
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"echo The real build spec will be put together by the custom resource\",\n        \"exit 1\"\n      ]\n    }\n  }\n}",
+     "Type": "NO_SOURCE"
+    },
+    "Cache": {
+     "Type": "NO_CACHE"
+    },
+    "Description": "Lambda dependency packager for nodejs18.x in Turbo-Layer-Test",
+    "EncryptionKey": "alias/aws/s3",
+    "LogsConfig": {
+     "CloudWatchLogs": {
+      "GroupName": {
+       "Ref": "Nodejs18CodeBuildPackagerLogsE4807E34"
+      },
+      "Status": "ENABLED"
+     }
+    }
+   }
+  },
+  "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ]
+  },
+  "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "codebuild:StartBuild",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "Nodejs18CodeBuildPackager634BA08F",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": "s3:DeleteObject*",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Fn::GetAtt": [
+            "Nodejs18CodeBuildPackagerBucket79764435",
+            "Arn"
+           ]
+          },
+          "/*"
+         ]
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A",
+    "Roles": [
+     {
+      "Ref": "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5"
+     }
+    ]
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ]
+  },
+  "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+     },
+     "S3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5",
+      "Arn"
+     ]
+    },
+    "Description": "Turbo layer packager for nodejs18.x using CodeBuild",
+    "Environment": {
+     "Variables": {
+      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
+     }
+    },
+    "Handler": "index.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5",
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ]
+  },
+  "Nodejs18CodeBuildPackagerPackageHandlerLogRetentionAA03C43C": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 30
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ]
+  },
+  "Nodejs18CodeBuildPackagernpminlineLayerPackager99DCCE8B": {
+   "Type": "Custom::LayerPackager",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2",
+      "Arn"
+     ]
+    },
+    "ProjectName": {
+     "Ref": "Nodejs18CodeBuildPackager634BA08F"
+    },
+    "BucketName": {
+     "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+    },
+    "CodeBuildInstallCommands": [
+     "echo Installing Node.js 18",
+     "n 18"
+    ],
+    "PreinstallCommands": [],
+    "Commands": [
+     "npm i",
+     "mkdir nodejs",
+     "mv node_modules nodejs/"
+    ],
+    "PackagedDirectory": "nodejs",
+    "AssetBucket": {
+     "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+    },
+    "AssetKey": "3bf5aad3a5db75c30ba530f89f7210a1eddb01c9a91cf0427515e6ef904bc869.zip"
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackagerPackageHandlerLogRetentionAA03C43C",
+    "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5",
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildPackagernpminlineLayer66D8F642": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+     },
+     "S3Key": {
+      "Ref": "Nodejs18CodeBuildPackagernpminlineLayerPackager99DCCE8B"
+     }
+    },
+    "Description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition"
+   }
+  },
+  "Nodejs18CodeBuildPackagernpmLayerPackager65607D01": {
+   "Type": "Custom::LayerPackager",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2",
+      "Arn"
+     ]
+    },
+    "ProjectName": {
+     "Ref": "Nodejs18CodeBuildPackager634BA08F"
+    },
+    "BucketName": {
+     "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+    },
+    "CodeBuildInstallCommands": [
+     "echo Installing Node.js 18",
+     "n 18"
+    ],
+    "PreinstallCommands": [],
+    "Commands": [
+     "npm ci",
+     "mkdir nodejs",
+     "mv node_modules nodejs/"
+    ],
+    "PackagedDirectory": "nodejs",
+    "AssetBucket": {
+     "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+    },
+    "AssetKey": "4a976e712b238000c04b209e96ba28d7567d8bbc7954fbbc97de024697cd4147.zip"
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackagerPackageHandlerLogRetentionAA03C43C",
+    "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5",
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildPackagernpmLayer8B6CB973": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+     },
+     "S3Key": {
+      "Ref": "Nodejs18CodeBuildPackagernpmLayerPackager65607D01"
+     }
+    },
+    "Description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition"
+   }
+  },
+  "Nodejs18CodeBuildPackageryarnLayerPackager4C59A305": {
+   "Type": "Custom::LayerPackager",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2",
+      "Arn"
+     ]
+    },
+    "ProjectName": {
+     "Ref": "Nodejs18CodeBuildPackager634BA08F"
+    },
+    "BucketName": {
+     "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+    },
+    "CodeBuildInstallCommands": [
+     "echo Installing Node.js 18",
+     "n 18"
+    ],
+    "PreinstallCommands": [],
+    "Commands": [
+     "which yarn || npm install --global yarn",
+     "yarn install --check-files --frozen-lockfile",
+     "mkdir nodejs",
+     "mv node_modules nodejs/"
+    ],
+    "PackagedDirectory": "nodejs",
+    "AssetBucket": {
+     "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+    },
+    "AssetKey": "48521f734f8d682c72f0a91cf94ae3031c21aa5c06f2b05888e7f98061118c64.zip"
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildPackagerPackageHandlerLogRetentionAA03C43C",
+    "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A",
+    "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5",
+    "Nodejs18CodeBuildPackager634BA08F",
+    "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+    "Nodejs18CodeBuildPackagerRole6D628672"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildPackageryarnLayer3299566A": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+     },
+     "S3Key": {
+      "Ref": "Nodejs18CodeBuildPackageryarnLayerPackager4C59A305"
+     }
+    },
+    "Description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition"
+   }
+  },
+  "Nodejs18CodeBuildNPMInlineTestServiceRoleA84C1254": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18CodeBuildNPMInlineTest2E004270": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildNPMInlineTestServiceRoleA84C1254",
+      "Arn"
+     ]
+    },
+    "Description": "Test npm nodejs18.x 1",
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "Nodejs18CodeBuildPackagernpminlineLayer66D8F642"
+     }
+    ],
+    "Runtime": "nodejs18.x",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildNPMInlineTestServiceRoleA84C1254"
+   ]
+  },
+  "Nodejs18CodeBuildNPMInlineTestLogRetentionEA1A4245": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18CodeBuildNPMInlineTest2E004270"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 1
+   }
+  },
+  "Nodejs18CodeBuildNPMInlineTestTrigger07F19AF0": {
+   "Type": "Custom::Trigger",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91",
+      "Arn"
+     ]
+    },
+    "HandlerArn": {
+     "Ref": "Nodejs18CodeBuildNPMInlineTestCurrentVersion407B373Ab5ec84688a3aa5d87ca817539e551d72"
+    },
+    "InvocationType": "RequestResponse",
+    "Timeout": "60000"
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildNPMInlineTestCurrentVersion407B373Ab5ec84688a3aa5d87ca817539e551d72": {
+   "Type": "AWS::Lambda::Version",
+   "Properties": {
+    "FunctionName": {
+     "Ref": "Nodejs18CodeBuildNPMInlineTest2E004270"
+    }
+   }
+  },
+  "Nodejs18CodeBuildNPMTestServiceRoleA521C672": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18CodeBuildNPMTest4642EE2D": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildNPMTestServiceRoleA521C672",
+      "Arn"
+     ]
+    },
+    "Description": "Test npm nodejs18.x 1",
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "Nodejs18CodeBuildPackagernpmLayer8B6CB973"
+     }
+    ],
+    "Runtime": "nodejs18.x",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildNPMTestServiceRoleA521C672"
+   ]
+  },
+  "Nodejs18CodeBuildNPMTestLogRetention261516D8": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18CodeBuildNPMTest4642EE2D"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 1
+   }
+  },
+  "Nodejs18CodeBuildNPMTestTrigger0856CACF": {
+   "Type": "Custom::Trigger",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91",
+      "Arn"
+     ]
+    },
+    "HandlerArn": {
+     "Ref": "Nodejs18CodeBuildNPMTestCurrentVersionDACB1E7Eb4c2d438bf2ccf1faa578e9a571c08cb"
+    },
+    "InvocationType": "RequestResponse",
+    "Timeout": "60000"
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildNPMTestCurrentVersionDACB1E7Eb4c2d438bf2ccf1faa578e9a571c08cb": {
+   "Type": "AWS::Lambda::Version",
+   "Properties": {
+    "FunctionName": {
+     "Ref": "Nodejs18CodeBuildNPMTest4642EE2D"
+    }
+   }
+  },
+  "Nodejs18CodeBuildYarnTestServiceRole137F64A5": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18CodeBuildYarnTest4486EC0A": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18CodeBuildYarnTestServiceRole137F64A5",
+      "Arn"
+     ]
+    },
+    "Description": "Test yarn nodejs18.x 1",
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "Nodejs18CodeBuildPackageryarnLayer3299566A"
+     }
+    ],
+    "Runtime": "nodejs18.x",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "Nodejs18CodeBuildYarnTestServiceRole137F64A5"
+   ]
+  },
+  "Nodejs18CodeBuildYarnTestLogRetention5ECA4C10": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18CodeBuildYarnTest4486EC0A"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 1
+   }
+  },
+  "Nodejs18CodeBuildYarnTestTrigger66F49BAB": {
+   "Type": "Custom::Trigger",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91",
+      "Arn"
+     ]
+    },
+    "HandlerArn": {
+     "Ref": "Nodejs18CodeBuildYarnTestCurrentVersionD2B4C7E1a12d430817114c39b1702076f2c82aad"
+    },
+    "InvocationType": "RequestResponse",
+    "Timeout": "60000"
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18CodeBuildYarnTestCurrentVersionD2B4C7E1a12d430817114c39b1702076f2c82aad": {
+   "Type": "AWS::Lambda::Version",
+   "Properties": {
+    "FunctionName": {
+     "Ref": "Nodejs18CodeBuildYarnTest4486EC0A"
+    }
+   }
+  },
+  "Nodejs18LambdaPackagerBucket8961068E": {
+   "Type": "AWS::S3::Bucket",
+   "Properties": {
+    "Tags": [
+     {
+      "Key": "aws-cdk:auto-delete-objects",
+      "Value": "true"
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaPackagerBucketPolicy4A9F35C6": {
+   "Type": "AWS::S3::BucketPolicy",
+   "Properties": {
+    "Bucket": {
+     "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+    },
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "s3:GetBucket*",
+        "s3:List*",
+        "s3:DeleteObject*"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "AWS": {
+         "Fn::GetAtt": [
+          "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+          "Arn"
+         ]
+        }
+       },
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "Nodejs18LambdaPackagerBucket8961068E",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "Nodejs18LambdaPackagerBucket8961068E",
+             "Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "Nodejs18LambdaPackagerBucketAutoDeleteObjectsCustomResourceD8AEE71D": {
+   "Type": "Custom::S3AutoDeleteObjects",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "Arn"
+     ]
+    },
+    "BucketName": {
+     "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+    }
+   },
+   "DependsOn": [
+    "Nodejs18LambdaPackagerBucketPolicy4A9F35C6"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaPackagerServiceRole7E341DE4": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "s3:DeleteObject*",
+        "s3:PutObject",
+        "s3:PutObjectLegalHold",
+        "s3:PutObjectRetention",
+        "s3:PutObjectTagging",
+        "s3:PutObjectVersionTagging",
+        "s3:Abort*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "Nodejs18LambdaPackagerBucket8961068E",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "Nodejs18LambdaPackagerBucket8961068E",
+             "Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      },
+      {
+       "Action": "s3:DeleteObject*",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Fn::GetAtt": [
+            "Nodejs18LambdaPackagerBucket8961068E",
+            "Arn"
+           ]
+          },
+          "/*"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "s3:GetObject*",
+        "s3:GetBucket*",
+        "s3:List*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+           }
+          ]
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A",
+    "Roles": [
+     {
+      "Ref": "Nodejs18LambdaPackagerServiceRole7E341DE4"
+     }
+    ]
+   }
+  },
+  "Nodejs18LambdaPackager85BAE326": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+     },
+     "S3Key": "d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaPackagerServiceRole7E341DE4",
+      "Arn"
+     ]
+    },
+    "Architectures": [
+     "x86_64"
+    ],
+    "Description": "Turbo layer packager for nodejs18.x",
+    "Environment": {
+     "Variables": {
+      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
+     }
+    },
+    "EphemeralStorage": {
+     "Size": 10240
+    },
+    "Handler": "index.handler",
+    "MemorySize": 1024,
+    "Runtime": "nodejs18.x",
+    "Timeout": 900
+   },
+   "DependsOn": [
+    "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A",
+    "Nodejs18LambdaPackagerServiceRole7E341DE4"
+   ]
+  },
+  "Nodejs18LambdaPackagerLogRetention8EEAD47C": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18LambdaPackager85BAE326"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 30
+   }
+  },
+  "Nodejs18LambdaPackagernpminlineLayerPackagerB88C3747": {
+   "Type": "Custom::LayerPackager",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaPackager85BAE326",
+      "Arn"
+     ]
+    },
+    "BucketName": {
+     "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+    },
+    "CodeBuildInstallCommands": [
+     "echo Installing Node.js 18",
+     "n 18"
+    ],
+    "PreinstallCommands": [],
+    "Commands": [
+     "npm i",
+     "mkdir nodejs",
+     "mv node_modules nodejs/"
+    ],
+    "PackagedDirectory": "nodejs",
+    "AssetBucket": {
+     "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+    },
+    "AssetKey": "3bf5aad3a5db75c30ba530f89f7210a1eddb01c9a91cf0427515e6ef904bc869.zip"
+   },
+   "DependsOn": [
+    "Nodejs18LambdaPackagerLogRetention8EEAD47C",
+    "Nodejs18LambdaPackager85BAE326",
+    "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A",
+    "Nodejs18LambdaPackagerServiceRole7E341DE4"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaPackagernpminlineLayer49352DA7": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+     },
+     "S3Key": {
+      "Ref": "Nodejs18LambdaPackagernpminlineLayerPackagerB88C3747"
+     }
+    },
+    "Description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition"
+   }
+  },
+  "Nodejs18LambdaPackagernpmLayerPackagerBFA1C741": {
+   "Type": "Custom::LayerPackager",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaPackager85BAE326",
+      "Arn"
+     ]
+    },
+    "BucketName": {
+     "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+    },
+    "CodeBuildInstallCommands": [
+     "echo Installing Node.js 18",
+     "n 18"
+    ],
+    "PreinstallCommands": [],
+    "Commands": [
+     "npm ci",
+     "mkdir nodejs",
+     "mv node_modules nodejs/"
+    ],
+    "PackagedDirectory": "nodejs",
+    "AssetBucket": {
+     "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+    },
+    "AssetKey": "4a976e712b238000c04b209e96ba28d7567d8bbc7954fbbc97de024697cd4147.zip"
+   },
+   "DependsOn": [
+    "Nodejs18LambdaPackagerLogRetention8EEAD47C",
+    "Nodejs18LambdaPackager85BAE326",
+    "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A",
+    "Nodejs18LambdaPackagerServiceRole7E341DE4"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaPackagernpmLayerDD458507": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+     },
+     "S3Key": {
+      "Ref": "Nodejs18LambdaPackagernpmLayerPackagerBFA1C741"
+     }
+    },
+    "Description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition"
+   }
+  },
+  "Nodejs18LambdaPackageryarnLayerPackager428E1F0F": {
+   "Type": "Custom::LayerPackager",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaPackager85BAE326",
+      "Arn"
+     ]
+    },
+    "BucketName": {
+     "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+    },
+    "CodeBuildInstallCommands": [
+     "echo Installing Node.js 18",
+     "n 18"
+    ],
+    "PreinstallCommands": [],
+    "Commands": [
+     "which yarn || npm install --global yarn",
+     "yarn install --check-files --frozen-lockfile",
+     "mkdir nodejs",
+     "mv node_modules nodejs/"
+    ],
+    "PackagedDirectory": "nodejs",
+    "AssetBucket": {
+     "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+    },
+    "AssetKey": "48521f734f8d682c72f0a91cf94ae3031c21aa5c06f2b05888e7f98061118c64.zip"
+   },
+   "DependsOn": [
+    "Nodejs18LambdaPackagerLogRetention8EEAD47C",
+    "Nodejs18LambdaPackager85BAE326",
+    "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A",
+    "Nodejs18LambdaPackagerServiceRole7E341DE4"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaPackageryarnLayer52A0260C": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+     },
+     "S3Key": {
+      "Ref": "Nodejs18LambdaPackageryarnLayerPackager428E1F0F"
+     }
+    },
+    "Description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition"
+   }
+  },
+  "Nodejs18LambdaNPMInlineTestServiceRole5E208618": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18LambdaNPMInlineTest3C9BC6C6": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaNPMInlineTestServiceRole5E208618",
+      "Arn"
+     ]
+    },
+    "Description": "Test npm nodejs18.x 0",
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "Nodejs18LambdaPackagernpminlineLayer49352DA7"
+     }
+    ],
+    "Runtime": "nodejs18.x",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "Nodejs18LambdaNPMInlineTestServiceRole5E208618"
+   ]
+  },
+  "Nodejs18LambdaNPMInlineTestLogRetentionFD2F8351": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18LambdaNPMInlineTest3C9BC6C6"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 1
+   }
+  },
+  "Nodejs18LambdaNPMInlineTestTriggerE22A7460": {
+   "Type": "Custom::Trigger",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91",
+      "Arn"
+     ]
+    },
+    "HandlerArn": {
+     "Ref": "Nodejs18LambdaNPMInlineTestCurrentVersion6041FE859b5523c462a9d9e2a02bf04e65c60a4c"
+    },
+    "InvocationType": "RequestResponse",
+    "Timeout": "60000"
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaNPMInlineTestCurrentVersion6041FE859b5523c462a9d9e2a02bf04e65c60a4c": {
+   "Type": "AWS::Lambda::Version",
+   "Properties": {
+    "FunctionName": {
+     "Ref": "Nodejs18LambdaNPMInlineTest3C9BC6C6"
+    }
+   }
+  },
+  "Nodejs18LambdaNPMTestServiceRoleB5A92577": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18LambdaNPMTest880421DA": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaNPMTestServiceRoleB5A92577",
+      "Arn"
+     ]
+    },
+    "Description": "Test npm nodejs18.x 0",
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "Nodejs18LambdaPackagernpmLayerDD458507"
+     }
+    ],
+    "Runtime": "nodejs18.x",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "Nodejs18LambdaNPMTestServiceRoleB5A92577"
+   ]
+  },
+  "Nodejs18LambdaNPMTestLogRetentionE14F43A7": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18LambdaNPMTest880421DA"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 1
+   }
+  },
+  "Nodejs18LambdaNPMTestTrigger131AD264": {
+   "Type": "Custom::Trigger",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91",
+      "Arn"
+     ]
+    },
+    "HandlerArn": {
+     "Ref": "Nodejs18LambdaNPMTestCurrentVersion301002D43b737a94284bca1c955570765e9c0adb"
+    },
+    "InvocationType": "RequestResponse",
+    "Timeout": "60000"
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaNPMTestCurrentVersion301002D43b737a94284bca1c955570765e9c0adb": {
+   "Type": "AWS::Lambda::Version",
+   "Properties": {
+    "FunctionName": {
+     "Ref": "Nodejs18LambdaNPMTest880421DA"
+    }
+   }
+  },
+  "Nodejs18LambdaYarnTestServiceRole155A0993": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "Nodejs18LambdaYarnTestAE6021EA": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "Nodejs18LambdaYarnTestServiceRole155A0993",
+      "Arn"
+     ]
+    },
+    "Description": "Test yarn nodejs18.x 0",
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "Nodejs18LambdaPackageryarnLayer52A0260C"
+     }
+    ],
+    "Runtime": "nodejs18.x",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "Nodejs18LambdaYarnTestServiceRole155A0993"
+   ]
+  },
+  "Nodejs18LambdaYarnTestLogRetentionD6464F47": {
+   "Type": "Custom::LogRetention",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+      "Arn"
+     ]
+    },
+    "LogGroupName": {
+     "Fn::Join": [
+      "",
+      [
+       "/aws/lambda/",
+       {
+        "Ref": "Nodejs18LambdaYarnTestAE6021EA"
+       }
+      ]
+     ]
+    },
+    "RetentionInDays": 1
+   }
+  },
+  "Nodejs18LambdaYarnTestTrigger7A3176ED": {
+   "Type": "Custom::Trigger",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "AWSCDKTriggerCustomResourceProviderCustomResourceProviderHandler97BECD91",
+      "Arn"
+     ]
+    },
+    "HandlerArn": {
+     "Ref": "Nodejs18LambdaYarnTestCurrentVersionC6BD10EFa0da227130f722d956db41bacc92cca8"
+    },
+    "InvocationType": "RequestResponse",
+    "Timeout": "60000"
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete"
+  },
+  "Nodejs18LambdaYarnTestCurrentVersionC6BD10EFa0da227130f722d956db41bacc92cca8": {
+   "Type": "AWS::Lambda::Version",
+   "Properties": {
+    "FunctionName": {
+     "Ref": "Nodejs18LambdaYarnTestAE6021EA"
+    }
+   }
+  },
   "Ruby27CodeBuildPackagerBucketD708F0AD": {
    "Type": "AWS::S3::Bucket",
    "Properties": {
@@ -4850,7 +6731,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+     "S3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -5968,7 +7849,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+     "S3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
     },
     "Role": {
      "Fn::GetAtt": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/70e2efee6f5ed2f653455df94122c9a80e1f3c3fcfbc96517e2bf4476741499d.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/12fc37fe63c4e8c1cd414d9f88013e6fb727d50abee15fed3294a634b955ce38.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -883,6 +883,366 @@
           {
             "type": "aws:cdk:logicalId",
             "data": "Nodejs16LambdaYarnTestCurrentVersion7E1F1E0E700262356e13bbf971efaf760dbf7ba5"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerBucket79764435"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/Policy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerBucketPolicy1FFB1A92"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerBucketAutoDeleteObjectsCustomResourceF163B54A"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Logs/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerLogsE4807E34"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerRole6D628672"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackager634BA08F"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerPackageHandlerC425E4C2"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagerPackageHandlerLogRetentionAA03C43C"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer Packager/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagernpminlineLayerPackager99DCCE8B"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagernpminlineLayer66D8F642"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer Packager/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagernpmLayerPackager65607D01"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackagernpmLayer8B6CB973"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer Packager/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackageryarnLayerPackager4C59A305"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildPackageryarnLayer3299566A"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMInlineTestServiceRoleA84C1254"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMInlineTest2E004270"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMInlineTestLogRetentionEA1A4245"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Trigger/Default/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMInlineTestTrigger07F19AF0"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/CurrentVersion/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMInlineTestCurrentVersion407B373Ab5ec84688a3aa5d87ca817539e551d72"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMTestServiceRoleA521C672"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMTest4642EE2D"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMTestLogRetention261516D8"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Trigger/Default/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMTestTrigger0856CACF"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/CurrentVersion/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildNPMTestCurrentVersionDACB1E7Eb4c2d438bf2ccf1faa578e9a571c08cb"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildYarnTestServiceRole137F64A5"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildYarnTest4486EC0A"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildYarnTestLogRetention5ECA4C10"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Trigger/Default/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildYarnTestTrigger66F49BAB"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/CurrentVersion/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18CodeBuildYarnTestCurrentVersionD2B4C7E1a12d430817114c39b1702076f2c82aad"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagerBucket8961068E"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/Policy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagerBucketPolicy4A9F35C6"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagerBucketAutoDeleteObjectsCustomResourceD8AEE71D"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagerServiceRole7E341DE4"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackager85BAE326"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagerLogRetention8EEAD47C"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer Packager/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagernpminlineLayerPackagerB88C3747"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagernpminlineLayer49352DA7"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer Packager/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagernpmLayerPackagerBFA1C741"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackagernpmLayerDD458507"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer Packager/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackageryarnLayerPackager428E1F0F"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaPackageryarnLayer52A0260C"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMInlineTestServiceRole5E208618"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMInlineTest3C9BC6C6"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMInlineTestLogRetentionFD2F8351"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Trigger/Default/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMInlineTestTriggerE22A7460"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/CurrentVersion/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMInlineTestCurrentVersion6041FE859b5523c462a9d9e2a02bf04e65c60a4c"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMTestServiceRoleB5A92577"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMTest880421DA"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMTestLogRetentionE14F43A7"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Trigger/Default/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMTestTrigger131AD264"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/CurrentVersion/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaNPMTestCurrentVersion301002D43b737a94284bca1c955570765e9c0adb"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaYarnTestServiceRole155A0993"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaYarnTestAE6021EA"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/LogRetention/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaYarnTestLogRetentionD6464F47"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Trigger/Default/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaYarnTestTrigger7A3176ED"
+          }
+        ],
+        "/Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/CurrentVersion/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "Nodejs18LambdaYarnTestCurrentVersionC6BD10EFa0da227130f722d956db41bacc92cca8"
           }
         ],
         "/Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Bucket/Resource": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "31.0.0",
+  "version": "32.0.0",
   "artifacts": {
     "Turbo-Layer-Test.assets": {
       "type": "cdk:asset-manifest",
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/12fc37fe63c4e8c1cd414d9f88013e6fb727d50abee15fed3294a634b955ce38.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3a503d4db4e69346c332bfe77fce8ce0c794379d3af40b21131b92e270d6c489.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -267,12 +267,6 @@
             "data": "Python39CodeBuildPoetryCurrentVersionDBDF4A62bda03456dafba602c33723cecd0fc0f7"
           }
         ],
-        "/Turbo-Layer-Test/DefaultCrNodeVersionMap": [
-          {
-            "type": "aws:cdk:logicalId",
-            "data": "DefaultCrNodeVersionMap"
-          }
-        ],
         "/Turbo-Layer-Test/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role": [
           {
             "type": "aws:cdk:logicalId",
@@ -301,6 +295,12 @@
           {
             "type": "aws:cdk:logicalId",
             "data": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A"
+          }
+        ],
+        "/Turbo-Layer-Test/DefaultCrNodeVersionMap": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "DefaultCrNodeVersionMap"
           }
         ],
         "/Turbo-Layer-Test/AWSCDK.TriggerCustomResourceProviderCustomResourceProvider/Role": [

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -36,7 +36,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -99,13 +99,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -117,19 +117,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Logs": {
@@ -147,13 +147,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -169,7 +169,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Packager/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -194,7 +194,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -419,19 +419,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -445,7 +445,7 @@
                             },
                             "environment": {
                               "type": "LINUX_CONTAINER",
-                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
                               "imagePullCredentialsType": "CODEBUILD",
                               "privilegedMode": false,
                               "computeType": "BUILD_GENERAL1_SMALL"
@@ -477,13 +477,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_codebuild.Project",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Package Handler": {
@@ -499,7 +499,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Package Handler/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -538,7 +538,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -594,19 +594,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -618,7 +618,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Package Handler/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -626,13 +626,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Package Handler/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -665,7 +665,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -677,13 +677,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Package Handler/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -691,13 +691,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/Package Handler/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "inline": {
@@ -713,7 +713,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/inline/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -721,13 +721,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/inline/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -739,13 +739,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/inline/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -771,13 +771,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -799,7 +799,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/req.txt/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -807,13 +807,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/req.txt/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -825,13 +825,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/req.txt/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -857,13 +857,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -885,7 +885,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/pipenv/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -893,13 +893,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/pipenv/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -911,13 +911,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/pipenv/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -943,13 +943,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -971,7 +971,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/poetry/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -979,13 +979,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/poetry/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -997,13 +997,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Packager/poetry/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -1029,13 +1029,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -1063,7 +1063,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Inline/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -1102,13 +1102,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -1139,7 +1139,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -1151,13 +1151,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Inline/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -1165,7 +1165,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Inline/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -1181,19 +1181,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Inline/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -1213,19 +1213,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Requirements.txt": {
@@ -1241,7 +1241,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Requirements.txt/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -1280,13 +1280,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -1317,7 +1317,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -1329,13 +1329,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Requirements.txt/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -1343,7 +1343,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Requirements.txt/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -1359,19 +1359,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Requirements.txt/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -1391,19 +1391,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Pipenv": {
@@ -1419,7 +1419,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Pipenv/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -1458,13 +1458,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -1495,7 +1495,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -1507,13 +1507,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Pipenv/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -1521,7 +1521,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Pipenv/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -1537,19 +1537,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Pipenv/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -1569,19 +1569,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Poetry": {
@@ -1597,7 +1597,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Poetry/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -1636,13 +1636,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -1673,7 +1673,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -1685,13 +1685,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Poetry/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -1699,7 +1699,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Poetry/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -1715,19 +1715,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 CodeBuild/Poetry/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -1747,33 +1747,25 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "constructs.Construct",
               "version": "10.0.5"
-            }
-          },
-          "DefaultCrNodeVersionMap": {
-            "id": "DefaultCrNodeVersionMap",
-            "path": "Turbo-Layer-Test/DefaultCrNodeVersionMap",
-            "constructInfo": {
-              "fqn": "aws-cdk-lib.CfnMapping",
-              "version": "2.77.0"
             }
           },
           "Custom::S3AutoDeleteObjectsCustomResourceProvider": {
@@ -1785,7 +1777,7 @@
                 "path": "Turbo-Layer-Test/Custom::S3AutoDeleteObjectsCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Role": {
@@ -1793,7 +1785,7 @@
                 "path": "Turbo-Layer-Test/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Handler": {
@@ -1801,13 +1793,13 @@
                 "path": "Turbo-Layer-Test/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProvider",
-              "version": "2.77.0"
+              "version": "2.87.0"
             }
           },
           "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a": {
@@ -1823,7 +1815,7 @@
                     "path": "Turbo-Layer-Test/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Code/Stage",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.AssetStaging",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "AssetBucket": {
@@ -1831,13 +1823,13 @@
                     "path": "Turbo-Layer-Test/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Code/AssetBucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "ServiceRole": {
@@ -1849,7 +1841,7 @@
                     "path": "Turbo-Layer-Test/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/ServiceRole/ImportServiceRole",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -1888,7 +1880,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "DefaultPolicy": {
@@ -1924,19 +1916,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Policy",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.aws_iam.Role",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Resource": {
@@ -1944,13 +1936,21 @@
                 "path": "Turbo-Layer-Test/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a/Resource",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "constructs.Construct",
               "version": "10.0.5"
+            }
+          },
+          "DefaultCrNodeVersionMap": {
+            "id": "DefaultCrNodeVersionMap",
+            "path": "Turbo-Layer-Test/DefaultCrNodeVersionMap",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnMapping",
+              "version": "2.87.0"
             }
           },
           "AWSCDK.TriggerCustomResourceProviderCustomResourceProvider": {
@@ -1962,7 +1962,7 @@
                 "path": "Turbo-Layer-Test/AWSCDK.TriggerCustomResourceProviderCustomResourceProvider/Staging",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.AssetStaging",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Role": {
@@ -1970,7 +1970,7 @@
                 "path": "Turbo-Layer-Test/AWSCDK.TriggerCustomResourceProviderCustomResourceProvider/Role",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Handler": {
@@ -1978,13 +1978,13 @@
                 "path": "Turbo-Layer-Test/AWSCDK.TriggerCustomResourceProviderCustomResourceProvider/Handler",
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.CfnResource",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
             "constructInfo": {
               "fqn": "aws-cdk-lib.CustomResourceProvider",
-              "version": "2.77.0"
+              "version": "2.87.0"
             }
           },
           "Python 3.9 Lambda": {
@@ -2015,7 +2015,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -2078,13 +2078,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -2096,19 +2096,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -2124,7 +2124,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/Packager/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -2163,7 +2163,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -2284,19 +2284,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -2308,7 +2308,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/Packager/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -2316,13 +2316,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/Packager/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -2358,7 +2358,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -2370,13 +2370,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/Packager/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -2384,13 +2384,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/Packager/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "inline": {
@@ -2406,7 +2406,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/inline/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -2414,13 +2414,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/inline/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -2432,13 +2432,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/inline/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -2464,13 +2464,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -2492,7 +2492,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/req.txt/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -2500,13 +2500,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/req.txt/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -2518,13 +2518,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/req.txt/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -2550,13 +2550,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -2578,7 +2578,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/pipenv/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -2586,13 +2586,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/pipenv/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -2604,13 +2604,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/pipenv/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -2636,13 +2636,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -2664,7 +2664,7 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/poetry/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -2672,13 +2672,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/poetry/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -2690,13 +2690,13 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Packager/poetry/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -2722,13 +2722,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -2756,7 +2756,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Inline/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -2795,13 +2795,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -2832,7 +2832,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -2844,13 +2844,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Inline/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -2858,7 +2858,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 Lambda/Inline/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -2874,19 +2874,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Inline/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -2906,19 +2906,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Requirements.txt": {
@@ -2934,7 +2934,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Requirements.txt/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -2973,13 +2973,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -3010,7 +3010,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -3022,13 +3022,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Requirements.txt/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -3036,7 +3036,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 Lambda/Requirements.txt/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -3052,19 +3052,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Requirements.txt/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -3084,19 +3084,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Pipenv": {
@@ -3112,7 +3112,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Pipenv/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -3151,13 +3151,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -3188,7 +3188,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -3200,13 +3200,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Pipenv/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -3214,7 +3214,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 Lambda/Pipenv/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -3230,19 +3230,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Pipenv/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -3262,19 +3262,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Poetry": {
@@ -3290,7 +3290,7 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Poetry/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -3329,13 +3329,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -3366,7 +3366,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -3378,13 +3378,13 @@
                         "path": "Turbo-Layer-Test/Python 3.9 Lambda/Poetry/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -3392,7 +3392,7 @@
                     "path": "Turbo-Layer-Test/Python 3.9 Lambda/Poetry/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -3408,19 +3408,19 @@
                             "path": "Turbo-Layer-Test/Python 3.9 Lambda/Poetry/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -3440,19 +3440,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -3489,7 +3489,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -3552,13 +3552,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -3570,19 +3570,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Logs": {
@@ -3600,13 +3600,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -3622,7 +3622,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Packager/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -3647,7 +3647,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -3872,19 +3872,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -3898,7 +3898,7 @@
                             },
                             "environment": {
                               "type": "LINUX_CONTAINER",
-                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
                               "imagePullCredentialsType": "CODEBUILD",
                               "privilegedMode": false,
                               "computeType": "BUILD_GENERAL1_SMALL"
@@ -3930,13 +3930,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_codebuild.Project",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Package Handler": {
@@ -3952,7 +3952,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Package Handler/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -3991,7 +3991,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -4047,19 +4047,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -4071,7 +4071,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Package Handler/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -4079,13 +4079,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Package Handler/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -4118,7 +4118,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -4130,13 +4130,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Package Handler/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -4144,13 +4144,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/Package Handler/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "npm inline": {
@@ -4166,7 +4166,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/npm inline/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -4174,13 +4174,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/npm inline/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -4192,13 +4192,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/npm inline/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -4224,13 +4224,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -4252,7 +4252,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/npm/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -4260,13 +4260,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/npm/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -4278,13 +4278,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/npm/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -4310,13 +4310,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -4338,7 +4338,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/yarn/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -4346,13 +4346,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/yarn/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -4364,13 +4364,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Packager/yarn/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -4396,13 +4396,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -4430,7 +4430,7 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Inline Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -4469,13 +4469,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -4506,7 +4506,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -4518,13 +4518,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Inline Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -4532,7 +4532,7 @@
                     "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Inline Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -4548,19 +4548,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Inline Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -4580,19 +4580,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "NPM Test": {
@@ -4608,7 +4608,7 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -4647,13 +4647,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -4684,7 +4684,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -4696,13 +4696,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -4710,7 +4710,7 @@
                     "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -4726,19 +4726,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/NPM Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -4758,19 +4758,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Yarn Test": {
@@ -4786,7 +4786,7 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Yarn Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -4825,13 +4825,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -4862,7 +4862,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -4874,13 +4874,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Yarn Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -4888,7 +4888,7 @@
                     "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Yarn Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -4904,19 +4904,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 CodeBuild/Yarn Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -4936,19 +4936,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -4985,7 +4985,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -5048,13 +5048,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -5066,19 +5066,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -5094,7 +5094,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/Packager/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -5133,7 +5133,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -5254,19 +5254,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -5278,7 +5278,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/Packager/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -5286,13 +5286,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/Packager/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -5333,7 +5333,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -5345,13 +5345,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/Packager/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -5359,13 +5359,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/Packager/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "npm inline": {
@@ -5381,7 +5381,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/npm inline/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -5389,13 +5389,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/npm inline/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -5407,13 +5407,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/npm inline/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -5439,13 +5439,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -5467,7 +5467,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/npm/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -5475,13 +5475,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/npm/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -5493,13 +5493,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/npm/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -5525,13 +5525,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -5553,7 +5553,7 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/yarn/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -5561,13 +5561,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/yarn/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -5579,13 +5579,13 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Packager/yarn/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -5611,13 +5611,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -5645,7 +5645,7 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Inline Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -5684,13 +5684,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -5721,7 +5721,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -5733,13 +5733,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Inline Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -5747,7 +5747,7 @@
                     "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Inline Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -5763,19 +5763,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Inline Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -5795,19 +5795,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "NPM Test": {
@@ -5823,7 +5823,7 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -5862,13 +5862,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -5899,7 +5899,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -5911,13 +5911,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -5925,7 +5925,7 @@
                     "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -5941,19 +5941,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/NPM Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -5973,19 +5973,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Yarn Test": {
@@ -6001,7 +6001,7 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/Yarn Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -6040,13 +6040,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -6077,7 +6077,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -6089,13 +6089,13 @@
                         "path": "Turbo-Layer-Test/Node.js 16 Lambda/Yarn Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -6103,7 +6103,7 @@
                     "path": "Turbo-Layer-Test/Node.js 16 Lambda/Yarn Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -6119,19 +6119,19 @@
                             "path": "Turbo-Layer-Test/Node.js 16 Lambda/Yarn Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -6151,19 +6151,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -6200,7 +6200,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -6263,13 +6263,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -6281,19 +6281,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Logs": {
@@ -6311,13 +6311,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -6333,7 +6333,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -6358,7 +6358,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -6583,19 +6583,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -6609,7 +6609,7 @@
                             },
                             "environment": {
                               "type": "LINUX_CONTAINER",
-                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
                               "imagePullCredentialsType": "CODEBUILD",
                               "privilegedMode": false,
                               "computeType": "BUILD_GENERAL1_SMALL"
@@ -6641,13 +6641,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_codebuild.Project",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Package Handler": {
@@ -6663,7 +6663,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -6702,7 +6702,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -6758,19 +6758,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -6782,7 +6782,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -6790,13 +6790,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -6829,7 +6829,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -6841,13 +6841,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -6855,13 +6855,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "npm inline": {
@@ -6877,7 +6877,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -6885,13 +6885,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -6903,13 +6903,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -6935,13 +6935,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -6963,7 +6963,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -6971,13 +6971,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -6989,13 +6989,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -7021,13 +7021,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -7049,7 +7049,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -7057,13 +7057,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -7075,13 +7075,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -7107,13 +7107,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -7141,7 +7141,7 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -7180,13 +7180,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -7217,7 +7217,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -7229,13 +7229,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -7243,7 +7243,7 @@
                     "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -7259,19 +7259,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -7291,19 +7291,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "NPM Test": {
@@ -7319,7 +7319,7 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -7358,13 +7358,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -7395,7 +7395,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -7407,13 +7407,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -7421,7 +7421,7 @@
                     "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -7437,19 +7437,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -7469,19 +7469,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Yarn Test": {
@@ -7497,7 +7497,7 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -7536,13 +7536,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -7573,7 +7573,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -7585,13 +7585,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -7599,7 +7599,7 @@
                     "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -7615,19 +7615,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -7647,19 +7647,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -7696,7 +7696,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -7759,13 +7759,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -7777,19 +7777,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -7805,7 +7805,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -7844,7 +7844,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -7965,19 +7965,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -7989,7 +7989,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -7997,13 +7997,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -8044,7 +8044,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -8056,13 +8056,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -8070,13 +8070,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "npm inline": {
@@ -8092,7 +8092,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -8100,13 +8100,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -8118,13 +8118,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -8150,13 +8150,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -8178,7 +8178,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -8186,13 +8186,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -8204,13 +8204,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -8236,13 +8236,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -8264,7 +8264,7 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -8272,13 +8272,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -8290,13 +8290,13 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -8322,13 +8322,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -8356,7 +8356,7 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -8395,13 +8395,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -8432,7 +8432,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -8444,13 +8444,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -8458,7 +8458,7 @@
                     "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -8474,19 +8474,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -8506,19 +8506,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "NPM Test": {
@@ -8534,7 +8534,7 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -8573,13 +8573,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -8610,7 +8610,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -8622,13 +8622,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -8636,7 +8636,7 @@
                     "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -8652,19 +8652,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -8684,19 +8684,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               },
               "Yarn Test": {
@@ -8712,7 +8712,7 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -8751,13 +8751,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -8788,7 +8788,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -8800,13 +8800,13 @@
                         "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -8814,7 +8814,7 @@
                     "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -8830,19 +8830,19 @@
                             "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -8862,19 +8862,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -8911,7 +8911,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -8974,13 +8974,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -8992,19 +8992,19 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Logs": {
@@ -9022,13 +9022,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -9044,7 +9044,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Packager/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -9069,7 +9069,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -9294,19 +9294,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -9320,7 +9320,7 @@
                             },
                             "environment": {
                               "type": "LINUX_CONTAINER",
-                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
                               "imagePullCredentialsType": "CODEBUILD",
                               "privilegedMode": false,
                               "computeType": "BUILD_GENERAL1_SMALL"
@@ -9352,13 +9352,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_codebuild.Project",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Package Handler": {
@@ -9374,7 +9374,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Package Handler/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -9413,7 +9413,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -9469,19 +9469,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -9493,7 +9493,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Package Handler/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -9501,13 +9501,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Package Handler/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -9540,7 +9540,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -9552,13 +9552,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Package Handler/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -9566,13 +9566,13 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/Package Handler/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "bundler": {
@@ -9588,7 +9588,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/bundler/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -9596,13 +9596,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/bundler/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -9614,13 +9614,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Packager/bundler/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -9646,13 +9646,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -9680,7 +9680,7 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Bundler Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -9719,13 +9719,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Code": {
@@ -9737,7 +9737,7 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Bundler Test/Code/Stage",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.AssetStaging",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AssetBucket": {
@@ -9745,13 +9745,13 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Bundler Test/Code/AssetBucket",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -9785,7 +9785,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -9797,13 +9797,13 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Bundler Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -9811,7 +9811,7 @@
                     "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Bundler Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -9827,19 +9827,19 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild/Bundler Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -9859,19 +9859,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -9908,7 +9908,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -9971,13 +9971,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -9989,19 +9989,19 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -10017,7 +10017,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/Packager/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -10056,7 +10056,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -10177,19 +10177,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -10201,7 +10201,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/Packager/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -10209,13 +10209,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/Packager/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -10251,7 +10251,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -10263,13 +10263,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/Packager/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -10277,13 +10277,13 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/Packager/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "bundler": {
@@ -10299,7 +10299,7 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/bundler/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -10307,13 +10307,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/bundler/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -10325,13 +10325,13 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Packager/bundler/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -10357,13 +10357,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -10391,7 +10391,7 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Bundler Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -10430,13 +10430,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Code": {
@@ -10448,7 +10448,7 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Bundler Test/Code/Stage",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.AssetStaging",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AssetBucket": {
@@ -10456,13 +10456,13 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Bundler Test/Code/AssetBucket",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -10496,7 +10496,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -10508,13 +10508,13 @@
                         "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Bundler Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -10522,7 +10522,7 @@
                     "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Bundler Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -10538,19 +10538,19 @@
                             "path": "Turbo-Layer-Test/Ruby 2.7 Lambda/Bundler Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -10570,19 +10570,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -10619,7 +10619,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Policy": {
@@ -10682,13 +10682,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AutoDeleteObjectsCustomResource": {
@@ -10700,19 +10700,19 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3.Bucket",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Logs": {
@@ -10730,13 +10730,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogGroup",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Packager": {
@@ -10752,7 +10752,7 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Packager/Role/ImportRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -10777,7 +10777,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -11002,19 +11002,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -11028,7 +11028,7 @@
                             },
                             "environment": {
                               "type": "LINUX_CONTAINER",
-                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
                               "imagePullCredentialsType": "CODEBUILD",
                               "privilegedMode": false,
                               "computeType": "BUILD_GENERAL1_SMALL"
@@ -11060,13 +11060,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_codebuild.Project",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Package Handler": {
@@ -11082,7 +11082,7 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Package Handler/ServiceRole/ImportServiceRole",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.Resource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "Resource": {
@@ -11121,7 +11121,7 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "DefaultPolicy": {
@@ -11177,19 +11177,19 @@
                                 },
                                 "constructInfo": {
                                   "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
-                                  "version": "2.77.0"
+                                  "version": "2.87.0"
                                 }
                               }
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_iam.Policy",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.Role",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Code": {
@@ -11201,7 +11201,7 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Package Handler/Code/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -11209,13 +11209,13 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Package Handler/Code/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -11248,7 +11248,7 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogRetention": {
@@ -11260,13 +11260,13 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Package Handler/LogRetention/Resource",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "LogGroup": {
@@ -11274,13 +11274,13 @@
                         "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/Package Handler/LogGroup",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Function",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "maven": {
@@ -11296,7 +11296,7 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/maven/Dependencies Definition/Stage",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.AssetStaging",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           },
                           "AssetBucket": {
@@ -11304,13 +11304,13 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/maven/Dependencies Definition/AssetBucket",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer Packager": {
@@ -11322,13 +11322,13 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Packager/maven/Layer Packager/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Layer": {
@@ -11354,13 +11354,13 @@
                             },
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
@@ -11388,7 +11388,7 @@
                         "path": "Turbo-Layer-Test/Java 11 CodeBuild/Maven Test/ServiceRole/ImportServiceRole",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.Resource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "Resource": {
@@ -11427,13 +11427,13 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_iam.CfnRole",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_iam.Role",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Code": {
@@ -11445,7 +11445,7 @@
                         "path": "Turbo-Layer-Test/Java 11 CodeBuild/Maven Test/Code/Stage",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.AssetStaging",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       },
                       "AssetBucket": {
@@ -11453,13 +11453,13 @@
                         "path": "Turbo-Layer-Test/Java 11 CodeBuild/Maven Test/Code/AssetBucket",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_s3.BucketBase",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Resource": {
@@ -11494,7 +11494,7 @@
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogRetention": {
@@ -11506,13 +11506,13 @@
                         "path": "Turbo-Layer-Test/Java 11 CodeBuild/Maven Test/LogRetention/Resource",
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CfnResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_logs.LogRetention",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "LogGroup": {
@@ -11520,7 +11520,7 @@
                     "path": "Turbo-Layer-Test/Java 11 CodeBuild/Maven Test/LogGroup",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.Resource",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "Trigger": {
@@ -11536,19 +11536,19 @@
                             "path": "Turbo-Layer-Test/Java 11 CodeBuild/Maven Test/Trigger/Default/Default",
                             "constructInfo": {
                               "fqn": "aws-cdk-lib.CfnResource",
-                              "version": "2.77.0"
+                              "version": "2.87.0"
                             }
                           }
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.CustomResource",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.triggers.Trigger",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   },
                   "CurrentVersion": {
@@ -11568,19 +11568,19 @@
                         },
                         "constructInfo": {
                           "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
-                          "version": "2.77.0"
+                          "version": "2.87.0"
                         }
                       }
                     },
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.aws_lambda.Version",
-                      "version": "2.77.0"
+                      "version": "2.87.0"
                     }
                   }
                 },
                 "constructInfo": {
                   "fqn": "aws-cdk-lib.triggers.TriggerFunction",
-                  "version": "2.77.0"
+                  "version": "2.87.0"
                 }
               }
             },
@@ -11594,7 +11594,7 @@
             "path": "Turbo-Layer-Test/BootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnParameter",
-              "version": "2.77.0"
+              "version": "2.87.0"
             }
           },
           "CheckBootstrapVersion": {
@@ -11602,13 +11602,13 @@
             "path": "Turbo-Layer-Test/CheckBootstrapVersion",
             "constructInfo": {
               "fqn": "aws-cdk-lib.CfnRule",
-              "version": "2.77.0"
+              "version": "2.87.0"
             }
           }
         },
         "constructInfo": {
           "fqn": "aws-cdk-lib.Stack",
-          "version": "2.77.0"
+          "version": "2.87.0"
         }
       },
       "Tree": {
@@ -11622,7 +11622,7 @@
     },
     "constructInfo": {
       "fqn": "aws-cdk-lib.App",
-      "version": "2.77.0"
+      "version": "2.87.0"
     }
   }
 }

--- a/test/default.integ.snapshot/tree.json
+++ b/test/default.integ.snapshot/tree.json
@@ -645,7 +645,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+                              "s3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -4098,7 +4098,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+                              "s3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -5305,7 +5305,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "75f547f8ec7caf5df0eae3fb02f0336444654208d287492b50cfe563b46b9588.zip"
+                              "s3Key": "d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -6172,6 +6172,2717 @@
               "version": "10.0.5"
             }
           },
+          "Node.js 18 CodeBuild": {
+            "id": "Node.js 18 CodeBuild",
+            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild",
+            "children": {
+              "Packager": {
+                "id": "Packager",
+                "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager",
+                "children": {
+                  "Bucket": {
+                    "id": "Bucket",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::S3::Bucket",
+                          "aws:cdk:cloudformation:props": {
+                            "tags": [
+                              {
+                                "key": "aws-cdk:auto-delete-objects",
+                                "value": "true"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Policy": {
+                        "id": "Policy",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/Policy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/Policy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::S3::BucketPolicy",
+                              "aws:cdk:cloudformation:props": {
+                                "bucket": {
+                                  "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+                                },
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "s3:GetBucket*",
+                                        "s3:List*",
+                                        "s3:DeleteObject*"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Principal": {
+                                        "AWS": {
+                                          "Fn::GetAtt": [
+                                            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                                            "Arn"
+                                          ]
+                                        }
+                                      },
+                                      "Resource": [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "Nodejs18CodeBuildPackagerBucket79764435",
+                                            "Arn"
+                                          ]
+                                        },
+                                        {
+                                          "Fn::Join": [
+                                            "",
+                                            [
+                                              {
+                                                "Fn::GetAtt": [
+                                                  "Nodejs18CodeBuildPackagerBucket79764435",
+                                                  "Arn"
+                                                ]
+                                              },
+                                              "/*"
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                }
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "AutoDeleteObjectsCustomResource": {
+                        "id": "AutoDeleteObjectsCustomResource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.Bucket",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Logs": {
+                    "id": "Logs",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Logs",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Logs/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Logs::LogGroup",
+                          "aws:cdk:cloudformation:props": {
+                            "retentionInDays": 30
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_logs.CfnLogGroup",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogGroup",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Packager": {
+                    "id": "Packager",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager",
+                    "children": {
+                      "Role": {
+                        "id": "Role",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role",
+                        "children": {
+                          "ImportRole": {
+                            "id": "ImportRole",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/ImportRole",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.Resource",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                              "aws:cdk:cloudformation:props": {
+                                "assumeRolePolicyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": "sts:AssumeRole",
+                                      "Effect": "Allow",
+                                      "Principal": {
+                                        "Service": "codebuild.amazonaws.com"
+                                      }
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                }
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "DefaultPolicy": {
+                            "id": "DefaultPolicy",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/DefaultPolicy",
+                            "children": {
+                              "Resource": {
+                                "id": "Resource",
+                                "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Role/DefaultPolicy/Resource",
+                                "attributes": {
+                                  "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                                  "aws:cdk:cloudformation:props": {
+                                    "policyDocument": {
+                                      "Statement": [
+                                        {
+                                          "Action": [
+                                            "logs:CreateLogStream",
+                                            "logs:PutLogEvents"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": {
+                                            "Fn::GetAtt": [
+                                              "Nodejs18CodeBuildPackagerLogsE4807E34",
+                                              "Arn"
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "Action": [
+                                            "logs:CreateLogGroup",
+                                            "logs:CreateLogStream",
+                                            "logs:PutLogEvents"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": [
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  "arn:",
+                                                  {
+                                                    "Ref": "AWS::Partition"
+                                                  },
+                                                  ":logs:",
+                                                  {
+                                                    "Ref": "AWS::Region"
+                                                  },
+                                                  ":",
+                                                  {
+                                                    "Ref": "AWS::AccountId"
+                                                  },
+                                                  ":log-group:/aws/codebuild/",
+                                                  {
+                                                    "Ref": "Nodejs18CodeBuildPackager634BA08F"
+                                                  }
+                                                ]
+                                              ]
+                                            },
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  "arn:",
+                                                  {
+                                                    "Ref": "AWS::Partition"
+                                                  },
+                                                  ":logs:",
+                                                  {
+                                                    "Ref": "AWS::Region"
+                                                  },
+                                                  ":",
+                                                  {
+                                                    "Ref": "AWS::AccountId"
+                                                  },
+                                                  ":log-group:/aws/codebuild/",
+                                                  {
+                                                    "Ref": "Nodejs18CodeBuildPackager634BA08F"
+                                                  },
+                                                  ":*"
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Action": [
+                                            "codebuild:CreateReportGroup",
+                                            "codebuild:CreateReport",
+                                            "codebuild:UpdateReport",
+                                            "codebuild:BatchPutTestCases",
+                                            "codebuild:BatchPutCodeCoverages"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": {
+                                            "Fn::Join": [
+                                              "",
+                                              [
+                                                "arn:",
+                                                {
+                                                  "Ref": "AWS::Partition"
+                                                },
+                                                ":codebuild:",
+                                                {
+                                                  "Ref": "AWS::Region"
+                                                },
+                                                ":",
+                                                {
+                                                  "Ref": "AWS::AccountId"
+                                                },
+                                                ":report-group/",
+                                                {
+                                                  "Ref": "Nodejs18CodeBuildPackager634BA08F"
+                                                },
+                                                "-*"
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "Action": [
+                                            "s3:DeleteObject*",
+                                            "s3:PutObject",
+                                            "s3:PutObjectLegalHold",
+                                            "s3:PutObjectRetention",
+                                            "s3:PutObjectTagging",
+                                            "s3:PutObjectVersionTagging",
+                                            "s3:Abort*"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": [
+                                            {
+                                              "Fn::GetAtt": [
+                                                "Nodejs18CodeBuildPackagerBucket79764435",
+                                                "Arn"
+                                              ]
+                                            },
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  {
+                                                    "Fn::GetAtt": [
+                                                      "Nodejs18CodeBuildPackagerBucket79764435",
+                                                      "Arn"
+                                                    ]
+                                                  },
+                                                  "/*"
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Action": "s3:DeleteObject*",
+                                          "Effect": "Allow",
+                                          "Resource": {
+                                            "Fn::Join": [
+                                              "",
+                                              [
+                                                {
+                                                  "Fn::GetAtt": [
+                                                    "Nodejs18CodeBuildPackagerBucket79764435",
+                                                    "Arn"
+                                                  ]
+                                                },
+                                                "/*"
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "Action": [
+                                            "s3:GetObject*",
+                                            "s3:GetBucket*",
+                                            "s3:List*"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": [
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  "arn:",
+                                                  {
+                                                    "Ref": "AWS::Partition"
+                                                  },
+                                                  ":s3:::",
+                                                  {
+                                                    "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                                                  }
+                                                ]
+                                              ]
+                                            },
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  "arn:",
+                                                  {
+                                                    "Ref": "AWS::Partition"
+                                                  },
+                                                  ":s3:::",
+                                                  {
+                                                    "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                                                  },
+                                                  "/*"
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Version": "2012-10-17"
+                                    },
+                                    "policyName": "Nodejs18CodeBuildPackagerRoleDefaultPolicyB84C7E27",
+                                    "roles": [
+                                      {
+                                        "Ref": "Nodejs18CodeBuildPackagerRole6D628672"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "constructInfo": {
+                                  "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                                  "version": "2.77.0"
+                                }
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.Policy",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Role",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Packager/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::CodeBuild::Project",
+                          "aws:cdk:cloudformation:props": {
+                            "artifacts": {
+                              "type": "NO_ARTIFACTS"
+                            },
+                            "environment": {
+                              "type": "LINUX_CONTAINER",
+                              "image": "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
+                              "imagePullCredentialsType": "CODEBUILD",
+                              "privilegedMode": false,
+                              "computeType": "BUILD_GENERAL1_SMALL"
+                            },
+                            "serviceRole": {
+                              "Fn::GetAtt": [
+                                "Nodejs18CodeBuildPackagerRole6D628672",
+                                "Arn"
+                              ]
+                            },
+                            "source": {
+                              "type": "NO_SOURCE",
+                              "buildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"echo The real build spec will be put together by the custom resource\",\n        \"exit 1\"\n      ]\n    }\n  }\n}"
+                            },
+                            "cache": {
+                              "type": "NO_CACHE"
+                            },
+                            "description": "Lambda dependency packager for nodejs18.x in Turbo-Layer-Test",
+                            "encryptionKey": "alias/aws/s3",
+                            "logsConfig": {
+                              "cloudWatchLogs": {
+                                "status": "ENABLED",
+                                "groupName": {
+                                  "Ref": "Nodejs18CodeBuildPackagerLogsE4807E34"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_codebuild.Project",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Package Handler": {
+                    "id": "Package Handler",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler",
+                    "children": {
+                      "ServiceRole": {
+                        "id": "ServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole",
+                        "children": {
+                          "ImportServiceRole": {
+                            "id": "ImportServiceRole",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/ImportServiceRole",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.Resource",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                              "aws:cdk:cloudformation:props": {
+                                "assumeRolePolicyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": "sts:AssumeRole",
+                                      "Effect": "Allow",
+                                      "Principal": {
+                                        "Service": "lambda.amazonaws.com"
+                                      }
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "managedPolicyArns": [
+                                  {
+                                    "Fn::Join": [
+                                      "",
+                                      [
+                                        "arn:",
+                                        {
+                                          "Ref": "AWS::Partition"
+                                        },
+                                        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "DefaultPolicy": {
+                            "id": "DefaultPolicy",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/DefaultPolicy",
+                            "children": {
+                              "Resource": {
+                                "id": "Resource",
+                                "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/ServiceRole/DefaultPolicy/Resource",
+                                "attributes": {
+                                  "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                                  "aws:cdk:cloudformation:props": {
+                                    "policyDocument": {
+                                      "Statement": [
+                                        {
+                                          "Action": "codebuild:StartBuild",
+                                          "Effect": "Allow",
+                                          "Resource": {
+                                            "Fn::GetAtt": [
+                                              "Nodejs18CodeBuildPackager634BA08F",
+                                              "Arn"
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "Action": "s3:DeleteObject*",
+                                          "Effect": "Allow",
+                                          "Resource": {
+                                            "Fn::Join": [
+                                              "",
+                                              [
+                                                {
+                                                  "Fn::GetAtt": [
+                                                    "Nodejs18CodeBuildPackagerBucket79764435",
+                                                    "Arn"
+                                                  ]
+                                                },
+                                                "/*"
+                                              ]
+                                            ]
+                                          }
+                                        }
+                                      ],
+                                      "Version": "2012-10-17"
+                                    },
+                                    "policyName": "Nodejs18CodeBuildPackagerPackageHandlerServiceRoleDefaultPolicy3B9AD09A",
+                                    "roles": [
+                                      {
+                                        "Ref": "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "constructInfo": {
+                                  "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                                  "version": "2.77.0"
+                                }
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.Policy",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Role",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Code": {
+                        "id": "Code",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Code",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Code/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Code/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                          "aws:cdk:cloudformation:props": {
+                            "code": {
+                              "s3Bucket": {
+                                "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                              },
+                              "s3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
+                            },
+                            "role": {
+                              "Fn::GetAtt": [
+                                "Nodejs18CodeBuildPackagerPackageHandlerServiceRole77FDFFB5",
+                                "Arn"
+                              ]
+                            },
+                            "description": "Turbo layer packager for nodejs18.x using CodeBuild",
+                            "environment": {
+                              "variables": {
+                                "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
+                              }
+                            },
+                            "handler": "index.handler",
+                            "runtime": "nodejs18.x"
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "LogRetention": {
+                        "id": "LogRetention",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/LogRetention",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/LogRetention/Resource",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "LogGroup": {
+                        "id": "LogGroup",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/Package Handler/LogGroup",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Function",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "npm inline": {
+                    "id": "npm inline",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline",
+                    "children": {
+                      "Dependencies Definition": {
+                        "id": "Dependencies Definition",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer Packager": {
+                        "id": "Layer Packager",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer Packager",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer Packager/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer": {
+                        "id": "Layer",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Layer/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                              "aws:cdk:cloudformation:props": {
+                                "content": {
+                                  "s3Bucket": {
+                                    "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+                                  },
+                                  "s3Key": {
+                                    "Ref": "Nodejs18CodeBuildPackagernpminlineLayerPackager99DCCE8B"
+                                  }
+                                },
+                                "description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm inline/Dependencies Definition"
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "constructs.Construct",
+                      "version": "10.0.5"
+                    }
+                  },
+                  "npm": {
+                    "id": "npm",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm",
+                    "children": {
+                      "Dependencies Definition": {
+                        "id": "Dependencies Definition",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer Packager": {
+                        "id": "Layer Packager",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer Packager",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer Packager/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer": {
+                        "id": "Layer",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Layer/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                              "aws:cdk:cloudformation:props": {
+                                "content": {
+                                  "s3Bucket": {
+                                    "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+                                  },
+                                  "s3Key": {
+                                    "Ref": "Nodejs18CodeBuildPackagernpmLayerPackager65607D01"
+                                  }
+                                },
+                                "description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/npm/Dependencies Definition"
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "constructs.Construct",
+                      "version": "10.0.5"
+                    }
+                  },
+                  "yarn": {
+                    "id": "yarn",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn",
+                    "children": {
+                      "Dependencies Definition": {
+                        "id": "Dependencies Definition",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer Packager": {
+                        "id": "Layer Packager",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer Packager",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer Packager/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer": {
+                        "id": "Layer",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Layer/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                              "aws:cdk:cloudformation:props": {
+                                "content": {
+                                  "s3Bucket": {
+                                    "Ref": "Nodejs18CodeBuildPackagerBucket79764435"
+                                  },
+                                  "s3Key": {
+                                    "Ref": "Nodejs18CodeBuildPackageryarnLayerPackager4C59A305"
+                                  }
+                                },
+                                "description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 CodeBuild/Packager/yarn/Dependencies Definition"
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "constructs.Construct",
+                      "version": "10.0.5"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.0.5"
+                }
+              },
+              "NPM Inline Test": {
+                "id": "NPM Inline Test",
+                "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test",
+                "children": {
+                  "ServiceRole": {
+                    "id": "ServiceRole",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/ServiceRole",
+                    "children": {
+                      "ImportServiceRole": {
+                        "id": "ImportServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/ServiceRole/ImportServiceRole",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/ServiceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "lambda.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                  ]
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                      "aws:cdk:cloudformation:props": {
+                        "code": {
+                          "zipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+                        },
+                        "role": {
+                          "Fn::GetAtt": [
+                            "Nodejs18CodeBuildNPMInlineTestServiceRoleA84C1254",
+                            "Arn"
+                          ]
+                        },
+                        "description": "Test npm nodejs18.x 1",
+                        "handler": "index.handler",
+                        "layers": [
+                          {
+                            "Ref": "Nodejs18CodeBuildPackagernpminlineLayer66D8F642"
+                          }
+                        ],
+                        "runtime": "nodejs18.x",
+                        "timeout": 60
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogRetention": {
+                    "id": "LogRetention",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/LogRetention",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/LogRetention/Resource",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogGroup": {
+                    "id": "LogGroup",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/LogGroup",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Trigger": {
+                    "id": "Trigger",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Trigger",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Trigger/Default",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/Trigger/Default/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.triggers.Trigger",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "CurrentVersion": {
+                    "id": "CurrentVersion",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/CurrentVersion",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Inline Test/CurrentVersion/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Version",
+                          "aws:cdk:cloudformation:props": {
+                            "functionName": {
+                              "Ref": "Nodejs18CodeBuildNPMInlineTest2E004270"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Version",
+                      "version": "2.77.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.triggers.TriggerFunction",
+                  "version": "2.77.0"
+                }
+              },
+              "NPM Test": {
+                "id": "NPM Test",
+                "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test",
+                "children": {
+                  "ServiceRole": {
+                    "id": "ServiceRole",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/ServiceRole",
+                    "children": {
+                      "ImportServiceRole": {
+                        "id": "ImportServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/ServiceRole/ImportServiceRole",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/ServiceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "lambda.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                  ]
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                      "aws:cdk:cloudformation:props": {
+                        "code": {
+                          "zipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+                        },
+                        "role": {
+                          "Fn::GetAtt": [
+                            "Nodejs18CodeBuildNPMTestServiceRoleA521C672",
+                            "Arn"
+                          ]
+                        },
+                        "description": "Test npm nodejs18.x 1",
+                        "handler": "index.handler",
+                        "layers": [
+                          {
+                            "Ref": "Nodejs18CodeBuildPackagernpmLayer8B6CB973"
+                          }
+                        ],
+                        "runtime": "nodejs18.x",
+                        "timeout": 60
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogRetention": {
+                    "id": "LogRetention",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/LogRetention",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/LogRetention/Resource",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogGroup": {
+                    "id": "LogGroup",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/LogGroup",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Trigger": {
+                    "id": "Trigger",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Trigger",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Trigger/Default",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/Trigger/Default/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.triggers.Trigger",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "CurrentVersion": {
+                    "id": "CurrentVersion",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/CurrentVersion",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/NPM Test/CurrentVersion/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Version",
+                          "aws:cdk:cloudformation:props": {
+                            "functionName": {
+                              "Ref": "Nodejs18CodeBuildNPMTest4642EE2D"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Version",
+                      "version": "2.77.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.triggers.TriggerFunction",
+                  "version": "2.77.0"
+                }
+              },
+              "Yarn Test": {
+                "id": "Yarn Test",
+                "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test",
+                "children": {
+                  "ServiceRole": {
+                    "id": "ServiceRole",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/ServiceRole",
+                    "children": {
+                      "ImportServiceRole": {
+                        "id": "ImportServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/ServiceRole/ImportServiceRole",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/ServiceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "lambda.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                  ]
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                      "aws:cdk:cloudformation:props": {
+                        "code": {
+                          "zipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+                        },
+                        "role": {
+                          "Fn::GetAtt": [
+                            "Nodejs18CodeBuildYarnTestServiceRole137F64A5",
+                            "Arn"
+                          ]
+                        },
+                        "description": "Test yarn nodejs18.x 1",
+                        "handler": "index.handler",
+                        "layers": [
+                          {
+                            "Ref": "Nodejs18CodeBuildPackageryarnLayer3299566A"
+                          }
+                        ],
+                        "runtime": "nodejs18.x",
+                        "timeout": 60
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogRetention": {
+                    "id": "LogRetention",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/LogRetention",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/LogRetention/Resource",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogGroup": {
+                    "id": "LogGroup",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/LogGroup",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Trigger": {
+                    "id": "Trigger",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Trigger",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Trigger/Default",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/Trigger/Default/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.triggers.Trigger",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "CurrentVersion": {
+                    "id": "CurrentVersion",
+                    "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/CurrentVersion",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 CodeBuild/Yarn Test/CurrentVersion/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Version",
+                          "aws:cdk:cloudformation:props": {
+                            "functionName": {
+                              "Ref": "Nodejs18CodeBuildYarnTest4486EC0A"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Version",
+                      "version": "2.77.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.triggers.TriggerFunction",
+                  "version": "2.77.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "constructs.Construct",
+              "version": "10.0.5"
+            }
+          },
+          "Node.js 18 Lambda": {
+            "id": "Node.js 18 Lambda",
+            "path": "Turbo-Layer-Test/Node.js 18 Lambda",
+            "children": {
+              "Packager": {
+                "id": "Packager",
+                "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager",
+                "children": {
+                  "Bucket": {
+                    "id": "Bucket",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::S3::Bucket",
+                          "aws:cdk:cloudformation:props": {
+                            "tags": [
+                              {
+                                "key": "aws-cdk:auto-delete-objects",
+                                "value": "true"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Policy": {
+                        "id": "Policy",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/Policy",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/Policy/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::S3::BucketPolicy",
+                              "aws:cdk:cloudformation:props": {
+                                "bucket": {
+                                  "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+                                },
+                                "policyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": [
+                                        "s3:GetBucket*",
+                                        "s3:List*",
+                                        "s3:DeleteObject*"
+                                      ],
+                                      "Effect": "Allow",
+                                      "Principal": {
+                                        "AWS": {
+                                          "Fn::GetAtt": [
+                                            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                                            "Arn"
+                                          ]
+                                        }
+                                      },
+                                      "Resource": [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "Nodejs18LambdaPackagerBucket8961068E",
+                                            "Arn"
+                                          ]
+                                        },
+                                        {
+                                          "Fn::Join": [
+                                            "",
+                                            [
+                                              {
+                                                "Fn::GetAtt": [
+                                                  "Nodejs18LambdaPackagerBucket8961068E",
+                                                  "Arn"
+                                                ]
+                                              },
+                                              "/*"
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                }
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "AutoDeleteObjectsCustomResource": {
+                        "id": "AutoDeleteObjectsCustomResource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Bucket/AutoDeleteObjectsCustomResource/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.Bucket",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Packager": {
+                    "id": "Packager",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager",
+                    "children": {
+                      "ServiceRole": {
+                        "id": "ServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole",
+                        "children": {
+                          "ImportServiceRole": {
+                            "id": "ImportServiceRole",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/ImportServiceRole",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.Resource",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                              "aws:cdk:cloudformation:props": {
+                                "assumeRolePolicyDocument": {
+                                  "Statement": [
+                                    {
+                                      "Action": "sts:AssumeRole",
+                                      "Effect": "Allow",
+                                      "Principal": {
+                                        "Service": "lambda.amazonaws.com"
+                                      }
+                                    }
+                                  ],
+                                  "Version": "2012-10-17"
+                                },
+                                "managedPolicyArns": [
+                                  {
+                                    "Fn::Join": [
+                                      "",
+                                      [
+                                        "arn:",
+                                        {
+                                          "Ref": "AWS::Partition"
+                                        },
+                                        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "DefaultPolicy": {
+                            "id": "DefaultPolicy",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/DefaultPolicy",
+                            "children": {
+                              "Resource": {
+                                "id": "Resource",
+                                "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/ServiceRole/DefaultPolicy/Resource",
+                                "attributes": {
+                                  "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                                  "aws:cdk:cloudformation:props": {
+                                    "policyDocument": {
+                                      "Statement": [
+                                        {
+                                          "Action": [
+                                            "s3:DeleteObject*",
+                                            "s3:PutObject",
+                                            "s3:PutObjectLegalHold",
+                                            "s3:PutObjectRetention",
+                                            "s3:PutObjectTagging",
+                                            "s3:PutObjectVersionTagging",
+                                            "s3:Abort*"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": [
+                                            {
+                                              "Fn::GetAtt": [
+                                                "Nodejs18LambdaPackagerBucket8961068E",
+                                                "Arn"
+                                              ]
+                                            },
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  {
+                                                    "Fn::GetAtt": [
+                                                      "Nodejs18LambdaPackagerBucket8961068E",
+                                                      "Arn"
+                                                    ]
+                                                  },
+                                                  "/*"
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Action": "s3:DeleteObject*",
+                                          "Effect": "Allow",
+                                          "Resource": {
+                                            "Fn::Join": [
+                                              "",
+                                              [
+                                                {
+                                                  "Fn::GetAtt": [
+                                                    "Nodejs18LambdaPackagerBucket8961068E",
+                                                    "Arn"
+                                                  ]
+                                                },
+                                                "/*"
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "Action": [
+                                            "s3:GetObject*",
+                                            "s3:GetBucket*",
+                                            "s3:List*"
+                                          ],
+                                          "Effect": "Allow",
+                                          "Resource": [
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  "arn:",
+                                                  {
+                                                    "Ref": "AWS::Partition"
+                                                  },
+                                                  ":s3:::",
+                                                  {
+                                                    "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                                                  }
+                                                ]
+                                              ]
+                                            },
+                                            {
+                                              "Fn::Join": [
+                                                "",
+                                                [
+                                                  "arn:",
+                                                  {
+                                                    "Ref": "AWS::Partition"
+                                                  },
+                                                  ":s3:::",
+                                                  {
+                                                    "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                                                  },
+                                                  "/*"
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "Version": "2012-10-17"
+                                    },
+                                    "policyName": "Nodejs18LambdaPackagerServiceRoleDefaultPolicy68AAA00A",
+                                    "roles": [
+                                      {
+                                        "Ref": "Nodejs18LambdaPackagerServiceRole7E341DE4"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "constructInfo": {
+                                  "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                                  "version": "2.77.0"
+                                }
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_iam.Policy",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.Role",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Code": {
+                        "id": "Code",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Code",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Code/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Code/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                          "aws:cdk:cloudformation:props": {
+                            "code": {
+                              "s3Bucket": {
+                                "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+                              },
+                              "s3Key": "d8e069c3d23367d81973703087b6be6d81ac1f0273b49cebb151001100ed95d5.zip"
+                            },
+                            "role": {
+                              "Fn::GetAtt": [
+                                "Nodejs18LambdaPackagerServiceRole7E341DE4",
+                                "Arn"
+                              ]
+                            },
+                            "architectures": [
+                              "x86_64"
+                            ],
+                            "description": "Turbo layer packager for nodejs18.x",
+                            "environment": {
+                              "variables": {
+                                "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
+                              }
+                            },
+                            "ephemeralStorage": {
+                              "size": 10240
+                            },
+                            "handler": "index.handler",
+                            "memorySize": 1024,
+                            "runtime": "nodejs18.x",
+                            "timeout": 900
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "LogRetention": {
+                        "id": "LogRetention",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/LogRetention",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/LogRetention/Resource",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "LogGroup": {
+                        "id": "LogGroup",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/Packager/LogGroup",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Function",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "npm inline": {
+                    "id": "npm inline",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline",
+                    "children": {
+                      "Dependencies Definition": {
+                        "id": "Dependencies Definition",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer Packager": {
+                        "id": "Layer Packager",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer Packager",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer Packager/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer": {
+                        "id": "Layer",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Layer/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                              "aws:cdk:cloudformation:props": {
+                                "content": {
+                                  "s3Bucket": {
+                                    "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+                                  },
+                                  "s3Key": {
+                                    "Ref": "Nodejs18LambdaPackagernpminlineLayerPackagerB88C3747"
+                                  }
+                                },
+                                "description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm inline/Dependencies Definition"
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "constructs.Construct",
+                      "version": "10.0.5"
+                    }
+                  },
+                  "npm": {
+                    "id": "npm",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm",
+                    "children": {
+                      "Dependencies Definition": {
+                        "id": "Dependencies Definition",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer Packager": {
+                        "id": "Layer Packager",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer Packager",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer Packager/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer": {
+                        "id": "Layer",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Layer/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                              "aws:cdk:cloudformation:props": {
+                                "content": {
+                                  "s3Bucket": {
+                                    "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+                                  },
+                                  "s3Key": {
+                                    "Ref": "Nodejs18LambdaPackagernpmLayerPackagerBFA1C741"
+                                  }
+                                },
+                                "description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 Lambda/Packager/npm/Dependencies Definition"
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "constructs.Construct",
+                      "version": "10.0.5"
+                    }
+                  },
+                  "yarn": {
+                    "id": "yarn",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn",
+                    "children": {
+                      "Dependencies Definition": {
+                        "id": "Dependencies Definition",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition",
+                        "children": {
+                          "Stage": {
+                            "id": "Stage",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition/Stage",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.AssetStaging",
+                              "version": "2.77.0"
+                            }
+                          },
+                          "AssetBucket": {
+                            "id": "AssetBucket",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition/AssetBucket",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer Packager": {
+                        "id": "Layer Packager",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer Packager",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer Packager/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Layer": {
+                        "id": "Layer",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer",
+                        "children": {
+                          "Resource": {
+                            "id": "Resource",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Layer/Resource",
+                            "attributes": {
+                              "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                              "aws:cdk:cloudformation:props": {
+                                "content": {
+                                  "s3Bucket": {
+                                    "Ref": "Nodejs18LambdaPackagerBucket8961068E"
+                                  },
+                                  "s3Key": {
+                                    "Ref": "Nodejs18LambdaPackageryarnLayerPackager428E1F0F"
+                                  }
+                                },
+                                "description": "Automatically generated by turbo layers for Turbo-Layer-Test/Node.js 18 Lambda/Packager/yarn/Dependencies Definition"
+                              }
+                            },
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.LayerVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "constructs.Construct",
+                      "version": "10.0.5"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "constructs.Construct",
+                  "version": "10.0.5"
+                }
+              },
+              "NPM Inline Test": {
+                "id": "NPM Inline Test",
+                "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test",
+                "children": {
+                  "ServiceRole": {
+                    "id": "ServiceRole",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/ServiceRole",
+                    "children": {
+                      "ImportServiceRole": {
+                        "id": "ImportServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/ServiceRole/ImportServiceRole",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/ServiceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "lambda.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                  ]
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                      "aws:cdk:cloudformation:props": {
+                        "code": {
+                          "zipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+                        },
+                        "role": {
+                          "Fn::GetAtt": [
+                            "Nodejs18LambdaNPMInlineTestServiceRole5E208618",
+                            "Arn"
+                          ]
+                        },
+                        "description": "Test npm nodejs18.x 0",
+                        "handler": "index.handler",
+                        "layers": [
+                          {
+                            "Ref": "Nodejs18LambdaPackagernpminlineLayer49352DA7"
+                          }
+                        ],
+                        "runtime": "nodejs18.x",
+                        "timeout": 60
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogRetention": {
+                    "id": "LogRetention",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/LogRetention",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/LogRetention/Resource",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogGroup": {
+                    "id": "LogGroup",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/LogGroup",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Trigger": {
+                    "id": "Trigger",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Trigger",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Trigger/Default",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/Trigger/Default/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.triggers.Trigger",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "CurrentVersion": {
+                    "id": "CurrentVersion",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/CurrentVersion",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Inline Test/CurrentVersion/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Version",
+                          "aws:cdk:cloudformation:props": {
+                            "functionName": {
+                              "Ref": "Nodejs18LambdaNPMInlineTest3C9BC6C6"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Version",
+                      "version": "2.77.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.triggers.TriggerFunction",
+                  "version": "2.77.0"
+                }
+              },
+              "NPM Test": {
+                "id": "NPM Test",
+                "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test",
+                "children": {
+                  "ServiceRole": {
+                    "id": "ServiceRole",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/ServiceRole",
+                    "children": {
+                      "ImportServiceRole": {
+                        "id": "ImportServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/ServiceRole/ImportServiceRole",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/ServiceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "lambda.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                  ]
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                      "aws:cdk:cloudformation:props": {
+                        "code": {
+                          "zipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+                        },
+                        "role": {
+                          "Fn::GetAtt": [
+                            "Nodejs18LambdaNPMTestServiceRoleB5A92577",
+                            "Arn"
+                          ]
+                        },
+                        "description": "Test npm nodejs18.x 0",
+                        "handler": "index.handler",
+                        "layers": [
+                          {
+                            "Ref": "Nodejs18LambdaPackagernpmLayerDD458507"
+                          }
+                        ],
+                        "runtime": "nodejs18.x",
+                        "timeout": 60
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogRetention": {
+                    "id": "LogRetention",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/LogRetention",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/LogRetention/Resource",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogGroup": {
+                    "id": "LogGroup",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/LogGroup",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Trigger": {
+                    "id": "Trigger",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Trigger",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Trigger/Default",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/Trigger/Default/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.triggers.Trigger",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "CurrentVersion": {
+                    "id": "CurrentVersion",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/CurrentVersion",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/NPM Test/CurrentVersion/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Version",
+                          "aws:cdk:cloudformation:props": {
+                            "functionName": {
+                              "Ref": "Nodejs18LambdaNPMTest880421DA"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Version",
+                      "version": "2.77.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.triggers.TriggerFunction",
+                  "version": "2.77.0"
+                }
+              },
+              "Yarn Test": {
+                "id": "Yarn Test",
+                "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test",
+                "children": {
+                  "ServiceRole": {
+                    "id": "ServiceRole",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/ServiceRole",
+                    "children": {
+                      "ImportServiceRole": {
+                        "id": "ImportServiceRole",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/ServiceRole/ImportServiceRole",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.Resource",
+                          "version": "2.77.0"
+                        }
+                      },
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/ServiceRole/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                          "aws:cdk:cloudformation:props": {
+                            "assumeRolePolicyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "sts:AssumeRole",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "Service": "lambda.amazonaws.com"
+                                  }
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "managedPolicyArns": [
+                              {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    "arn:",
+                                    {
+                                      "Ref": "AWS::Partition"
+                                    },
+                                    ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                                  ]
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Role",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                      "aws:cdk:cloudformation:props": {
+                        "code": {
+                          "zipFile": "module.exports.handler = (event, context, callback) => {require(\"lodash\");callback();}"
+                        },
+                        "role": {
+                          "Fn::GetAtt": [
+                            "Nodejs18LambdaYarnTestServiceRole155A0993",
+                            "Arn"
+                          ]
+                        },
+                        "description": "Test yarn nodejs18.x 0",
+                        "handler": "index.handler",
+                        "layers": [
+                          {
+                            "Ref": "Nodejs18LambdaPackageryarnLayer52A0260C"
+                          }
+                        ],
+                        "runtime": "nodejs18.x",
+                        "timeout": 60
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogRetention": {
+                    "id": "LogRetention",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/LogRetention",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/LogRetention/Resource",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_logs.LogRetention",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "LogGroup": {
+                    "id": "LogGroup",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/LogGroup",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "Trigger": {
+                    "id": "Trigger",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Trigger",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Trigger/Default",
+                        "children": {
+                          "Default": {
+                            "id": "Default",
+                            "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/Trigger/Default/Default",
+                            "constructInfo": {
+                              "fqn": "aws-cdk-lib.CfnResource",
+                              "version": "2.77.0"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CustomResource",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.triggers.Trigger",
+                      "version": "2.77.0"
+                    }
+                  },
+                  "CurrentVersion": {
+                    "id": "CurrentVersion",
+                    "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/CurrentVersion",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "Turbo-Layer-Test/Node.js 18 Lambda/Yarn Test/CurrentVersion/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::Lambda::Version",
+                          "aws:cdk:cloudformation:props": {
+                            "functionName": {
+                              "Ref": "Nodejs18LambdaYarnTestAE6021EA"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_lambda.CfnVersion",
+                          "version": "2.77.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.Version",
+                      "version": "2.77.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.triggers.TriggerFunction",
+                  "version": "2.77.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "constructs.Construct",
+              "version": "10.0.5"
+            }
+          },
           "Ruby 2.7 CodeBuild": {
             "id": "Ruby 2.7 CodeBuild",
             "path": "Turbo-Layer-Test/Ruby 2.7 CodeBuild",
@@ -6809,7 +9520,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+                              "s3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [
@@ -8517,7 +11228,7 @@
                               "s3Bucket": {
                                 "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
                               },
-                              "s3Key": "611fff8139d552c84d2e687a1cb26c16d91f18a3d5b311f3da290d2c651c3083.zip"
+                              "s3Key": "4ace167f140d06c41c4341333484cea99eca5faa4f0359d203839b3e7956a102.zip"
                             },
                             "role": {
                               "Fn::GetAtt": [

--- a/test/default.integ.ts
+++ b/test/default.integ.ts
@@ -169,6 +169,8 @@ new PythonTest(layerStack, 'Python 3.9 CodeBuild', lambda.Runtime.PYTHON_3_9, De
 new PythonTest(layerStack, 'Python 3.9 Lambda', lambda.Runtime.PYTHON_3_9, DependencyPackagerType.LAMBDA);
 new NodejsTest(layerStack, 'Node.js 16 CodeBuild', lambda.Runtime.NODEJS_16_X, DependencyPackagerType.CODEBUILD);
 new NodejsTest(layerStack, 'Node.js 16 Lambda', lambda.Runtime.NODEJS_16_X, DependencyPackagerType.LAMBDA);
+new NodejsTest(layerStack, 'Node.js 18 CodeBuild', lambda.Runtime.NODEJS_18_X, DependencyPackagerType.CODEBUILD);
+new NodejsTest(layerStack, 'Node.js 18 Lambda', lambda.Runtime.NODEJS_18_X, DependencyPackagerType.LAMBDA);
 new RubyTest(layerStack, 'Ruby 2.7 CodeBuild', lambda.Runtime.RUBY_2_7, DependencyPackagerType.CODEBUILD);
 new RubyTest(layerStack, 'Ruby 2.7 Lambda', lambda.Runtime.RUBY_2_7, DependencyPackagerType.LAMBDA);
 new JavaTest(layerStack, 'Java 11 CodeBuild', lambda.Runtime.JAVA_11, DependencyPackagerType.CODEBUILD);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.97":
+"@aws-cdk/asset-awscli-v1@^2.2.177":
   version "2.2.200"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz#6ead533f73f705ad7350eb46955e2538e50cd013"
   integrity sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==
@@ -25,7 +25,7 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz#d8e20b5f5dc20128ea2000dc479ca3c7ddc27248"
   integrity sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.77":
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.148":
   version "2.0.166"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.166.tgz#467507db141cd829ff8aa9d6ea5519310a4276b8"
   integrity sha512-j0xnccpUQHXJKPgCwQcGGNu4lRiC1PptYfdxBIH1L4dRK91iBxtSQHESRQX+yB47oGLaF/WfNN/aF3WXwlhikg==
@@ -2622,32 +2622,27 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.77.0:
-  version "2.77.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz#803031c2457bc5786ed14fbb967788fd526a9358"
-  integrity sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==
+aws-cdk-lib@2.87.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.87.0.tgz#585a2569fa139ffecc3ff40ffc399eb7da030a4a"
+  integrity sha512-9kirXX7L7OP/yGmCbaYlkt5OAtowGiGw0AYFIQvSwvx/UU3aJO5XuDwAgDsvToDkRpBi0yX0bNwqa0DItu+C6A==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.97"
+    "@aws-cdk/asset-awscli-v1" "^2.2.177"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.77"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.148"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^9.1.0"
+    fs-extra "^11.1.1"
     ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.3.0"
-    semver "^7.3.8"
+    semver "^7.5.1"
     table "^6.8.1"
     yaml "1.10.2"
 
@@ -4132,6 +4127,15 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -4140,16 +4144,6 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -7097,7 +7091,7 @@ semver-utils@^1.1.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4:
+semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.1, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,12 +35,603 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.101.0-alpha.0.tgz#1739ab864c223b49da8dedc9618b0331d84565a9"
   integrity sha512-ardpg+IbAH/BM6ZFZMTEUm6tQNf1YDCC4xyPBubh/Eakj/HvswQ1TlCiRdIBXaCuXseczKdaEVAhqObv6KXiig==
 
-"@aws-sdk/types@^3.428.0":
+"@aws-crypto/crc32@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-3.0.0.tgz#07300eca214409c33e3ff769cd5697b57fdd38fa"
+  integrity sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==
+  dependencies:
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/crc32c@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz#016c92da559ef638a84a245eecb75c3e97cb664f"
+  integrity sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==
+  dependencies:
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/ie11-detection@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz#640ae66b4ec3395cee6a8e94ebcd9f80c24cd688"
+  integrity sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha1-browser@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz#f9083c00782b24714f528b1a1fef2174002266a3"
+  integrity sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^3.0.0"
+    "@aws-crypto/supports-web-crypto" "^3.0.0"
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz#05f160138ab893f1c6ba5be57cfd108f05827766"
+  integrity sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^3.0.0"
+    "@aws-crypto/sha256-js" "^3.0.0"
+    "@aws-crypto/supports-web-crypto" "^3.0.0"
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@3.0.0", "@aws-crypto/sha256-js@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz#f06b84d550d25521e60d2a0e2a90139341e007c2"
+  integrity sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==
+  dependencies:
+    "@aws-crypto/util" "^3.0.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz#5d1bf825afa8072af2717c3e455f35cda0103ec2"
+  integrity sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-3.0.0.tgz#1c7ca90c29293f0883468ad48117937f0fe5bfb0"
+  integrity sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/client-codebuild@^3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-codebuild/-/client-codebuild-3.428.0.tgz#618ac28c027600f69eb58867f712628bcdb55bf1"
+  integrity sha512-jdcgkTYkeoJkdVu+aHzk6W6YVoZWf4Oo8UM3/IW+1mkSGScyf5HaUXt7yyDscvZ5pNpHjdxzb6N4abEaaBTccg==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.428.0"
+    "@aws-sdk/credential-provider-node" "3.428.0"
+    "@aws-sdk/middleware-host-header" "3.428.0"
+    "@aws-sdk/middleware-logger" "3.428.0"
+    "@aws-sdk/middleware-recursion-detection" "3.428.0"
+    "@aws-sdk/middleware-signing" "3.428.0"
+    "@aws-sdk/middleware-user-agent" "3.428.0"
+    "@aws-sdk/region-config-resolver" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-endpoints" "3.428.0"
+    "@aws-sdk/util-user-agent-browser" "3.428.0"
+    "@aws-sdk/util-user-agent-node" "3.428.0"
+    "@smithy/config-resolver" "^2.0.14"
+    "@smithy/fetch-http-handler" "^2.2.3"
+    "@smithy/hash-node" "^2.0.11"
+    "@smithy/invalid-dependency" "^2.0.11"
+    "@smithy/middleware-content-length" "^2.0.13"
+    "@smithy/middleware-endpoint" "^2.1.0"
+    "@smithy/middleware-retry" "^2.0.16"
+    "@smithy/middleware-serde" "^2.0.11"
+    "@smithy/middleware-stack" "^2.0.5"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/node-http-handler" "^2.1.7"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.15"
+    "@smithy/util-defaults-mode-node" "^2.0.19"
+    "@smithy/util-retry" "^2.0.4"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/client-s3@^3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.428.0.tgz#e16ccd17fbed77de784c0d1baddfd9e2b77d0bdd"
+  integrity sha512-qz4SV0sjeKC/m573Ox0wWhVABhN35cy0zBOvYixtEQNBzQbWefk8luHkNxntyybuLPZz6ChDzU98+EBac5RuRg==
+  dependencies:
+    "@aws-crypto/sha1-browser" "3.0.0"
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/client-sts" "3.428.0"
+    "@aws-sdk/credential-provider-node" "3.428.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.428.0"
+    "@aws-sdk/middleware-expect-continue" "3.428.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.428.0"
+    "@aws-sdk/middleware-host-header" "3.428.0"
+    "@aws-sdk/middleware-location-constraint" "3.428.0"
+    "@aws-sdk/middleware-logger" "3.428.0"
+    "@aws-sdk/middleware-recursion-detection" "3.428.0"
+    "@aws-sdk/middleware-sdk-s3" "3.428.0"
+    "@aws-sdk/middleware-signing" "3.428.0"
+    "@aws-sdk/middleware-ssec" "3.428.0"
+    "@aws-sdk/middleware-user-agent" "3.428.0"
+    "@aws-sdk/region-config-resolver" "3.428.0"
+    "@aws-sdk/signature-v4-multi-region" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-endpoints" "3.428.0"
+    "@aws-sdk/util-user-agent-browser" "3.428.0"
+    "@aws-sdk/util-user-agent-node" "3.428.0"
+    "@aws-sdk/xml-builder" "3.310.0"
+    "@smithy/config-resolver" "^2.0.14"
+    "@smithy/eventstream-serde-browser" "^2.0.11"
+    "@smithy/eventstream-serde-config-resolver" "^2.0.11"
+    "@smithy/eventstream-serde-node" "^2.0.11"
+    "@smithy/fetch-http-handler" "^2.2.3"
+    "@smithy/hash-blob-browser" "^2.0.11"
+    "@smithy/hash-node" "^2.0.11"
+    "@smithy/hash-stream-node" "^2.0.11"
+    "@smithy/invalid-dependency" "^2.0.11"
+    "@smithy/md5-js" "^2.0.11"
+    "@smithy/middleware-content-length" "^2.0.13"
+    "@smithy/middleware-endpoint" "^2.1.0"
+    "@smithy/middleware-retry" "^2.0.16"
+    "@smithy/middleware-serde" "^2.0.11"
+    "@smithy/middleware-stack" "^2.0.5"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/node-http-handler" "^2.1.7"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.15"
+    "@smithy/util-defaults-mode-node" "^2.0.19"
+    "@smithy/util-retry" "^2.0.4"
+    "@smithy/util-stream" "^2.0.16"
+    "@smithy/util-utf8" "^2.0.0"
+    "@smithy/util-waiter" "^2.0.11"
+    fast-xml-parser "4.2.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/client-sso@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.428.0.tgz#749bdc8aceb0cfcb59228903bb7f500836b32386"
+  integrity sha512-6BuY7cd1licnCZTKuI/IK3ycKATIgsG53TuaK1hZcikwUB2Oiu2z6K+aWpmO9mJuJ6qAoE4dLlAy6lBBBkG6yQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/middleware-host-header" "3.428.0"
+    "@aws-sdk/middleware-logger" "3.428.0"
+    "@aws-sdk/middleware-recursion-detection" "3.428.0"
+    "@aws-sdk/middleware-user-agent" "3.428.0"
+    "@aws-sdk/region-config-resolver" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-endpoints" "3.428.0"
+    "@aws-sdk/util-user-agent-browser" "3.428.0"
+    "@aws-sdk/util-user-agent-node" "3.428.0"
+    "@smithy/config-resolver" "^2.0.14"
+    "@smithy/fetch-http-handler" "^2.2.3"
+    "@smithy/hash-node" "^2.0.11"
+    "@smithy/invalid-dependency" "^2.0.11"
+    "@smithy/middleware-content-length" "^2.0.13"
+    "@smithy/middleware-endpoint" "^2.1.0"
+    "@smithy/middleware-retry" "^2.0.16"
+    "@smithy/middleware-serde" "^2.0.11"
+    "@smithy/middleware-stack" "^2.0.5"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/node-http-handler" "^2.1.7"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.15"
+    "@smithy/util-defaults-mode-node" "^2.0.19"
+    "@smithy/util-retry" "^2.0.4"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/client-sts@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.428.0.tgz#6df3d2c8edc6952ab7ec5eb26b7ca5aee572f501"
+  integrity sha512-ko9hgmIkS5FNPYtT3pntGGmp+yi+VXBEgePUBoplEKjCxsX/aTgFcq2Rs9duD9/CzkThd42Z0l0fWsVAErVxWQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/credential-provider-node" "3.428.0"
+    "@aws-sdk/middleware-host-header" "3.428.0"
+    "@aws-sdk/middleware-logger" "3.428.0"
+    "@aws-sdk/middleware-recursion-detection" "3.428.0"
+    "@aws-sdk/middleware-sdk-sts" "3.428.0"
+    "@aws-sdk/middleware-signing" "3.428.0"
+    "@aws-sdk/middleware-user-agent" "3.428.0"
+    "@aws-sdk/region-config-resolver" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-endpoints" "3.428.0"
+    "@aws-sdk/util-user-agent-browser" "3.428.0"
+    "@aws-sdk/util-user-agent-node" "3.428.0"
+    "@smithy/config-resolver" "^2.0.14"
+    "@smithy/fetch-http-handler" "^2.2.3"
+    "@smithy/hash-node" "^2.0.11"
+    "@smithy/invalid-dependency" "^2.0.11"
+    "@smithy/middleware-content-length" "^2.0.13"
+    "@smithy/middleware-endpoint" "^2.1.0"
+    "@smithy/middleware-retry" "^2.0.16"
+    "@smithy/middleware-serde" "^2.0.11"
+    "@smithy/middleware-stack" "^2.0.5"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/node-http-handler" "^2.1.7"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.15"
+    "@smithy/util-defaults-mode-node" "^2.0.19"
+    "@smithy/util-retry" "^2.0.4"
+    "@smithy/util-utf8" "^2.0.0"
+    fast-xml-parser "4.2.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-env@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.428.0.tgz#b977084e86491a6600d3831c8a70cc29472475dc"
+  integrity sha512-e6fbY174Idzw0r5ZMT1qkDh+dpOp1DX3ickhr7J6ipo3cUGLI45Y5lnR9nYXWfB5o/wiNv4zXgN+Y3ORJJHzyA==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-ini@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.428.0.tgz#f54148d34f985e196a29f51d22b900b87f7f66e7"
+  integrity sha512-JPc0pVAsP8fOfMxhmPhp7PjddqHaPGBwgVI+wgbkFRUDOmeKCVhoxCB8Womx0R07qRqD5ZCUKBS2NHQ2b3MFRQ==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.428.0"
+    "@aws-sdk/credential-provider-process" "3.428.0"
+    "@aws-sdk/credential-provider-sso" "3.428.0"
+    "@aws-sdk/credential-provider-web-identity" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.6"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-node@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.428.0.tgz#eff211f21d1ddf35cccd2d3f04eeb0dee3ccc2c7"
+  integrity sha512-o8toLXf6/sklBpw2e1mzAUq6SvXQzT6iag7Xbg9E0Z2EgVeXLTnWeVto3ilU3cmhTHXBp6wprwUUq2jbjTxMcg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.428.0"
+    "@aws-sdk/credential-provider-ini" "3.428.0"
+    "@aws-sdk/credential-provider-process" "3.428.0"
+    "@aws-sdk/credential-provider-sso" "3.428.0"
+    "@aws-sdk/credential-provider-web-identity" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.6"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-process@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.428.0.tgz#2b8242b3ff0e78d5e58259d1f305d81700c7e101"
+  integrity sha512-UG2S2/4Wrskbkbgt9fBlnzwQ2hfTXvLJwUgGOluSOf6+mGCcoDku4zzc9EQdk1MwN5Us+ziyMrIMNY5sbdLg6g==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.6"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-sso@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.428.0.tgz#192ae441c415ee66b10415545d7c35151fbb2abc"
+  integrity sha512-sW2+kSlICSNntsNhLV5apqJkIOXH5hFISCjwVfyB9JXJQDAj8rzkiFfRsKwQ3aTlTYCysrGesIn46+GRP5AgZw==
+  dependencies:
+    "@aws-sdk/client-sso" "3.428.0"
+    "@aws-sdk/token-providers" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.6"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/credential-provider-web-identity@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.428.0.tgz#d9d60d4ab919c973a3c3465c39cf950550dccb27"
+  integrity sha512-ueuUPPlrJFvtDUVTGnClUGt1wxCbEiKArknah/w9cfcc/c1HtFd/M7x/z2Sm0gSItR45sVcK54qjzmhm29DMzg==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-bucket-endpoint@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.428.0.tgz#f5e139eff974da8fa9e602e5f6a2970b0c1daae3"
+  integrity sha512-xZ/o6E7icVVTFlOLBKrIQJqFToL0KmWEGLFcaHhgCNz5gppEK2iGH9GondQotQPesiEyi46HwzM6GLNRylELww==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-arn-parser" "3.310.0"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-config-provider" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-expect-continue@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.428.0.tgz#441ee1026c33cf483e14501a28fe1ec2e4645bb6"
+  integrity sha512-d/vWUs9RD4fuO1oi7gJby6aEPb6XTf2+jCbrs/hUEYFMxQu7wwQx2c6BWAjfQca8zVadh7FY0cDNtL2Ep2d8zA==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-flexible-checksums@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.428.0.tgz#e04f64b6cbd0696a3765055341e0dd80d3822e14"
+  integrity sha512-O54XmBSvi9A6ZBRVSYrEvoGH1BjtR1TT8042gOdJgouI0OVWtjqHT2ZPVTbQ/rKW5QeLXszVloXFW6eqOwrVTg==
+  dependencies:
+    "@aws-crypto/crc32" "3.0.0"
+    "@aws-crypto/crc32c" "3.0.0"
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/is-array-buffer" "^2.0.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-host-header@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.428.0.tgz#6dd078ed9535f3514e0148d83387f9061722d3f9"
+  integrity sha512-iIHbW5Ym60ol9Q6vsLnaiNdeUIa9DA0OuoOe9LiHC8SYUYVAAhE+xJXUhn1qk/J7z+4qGOkDnVyEvnSaqRPL/w==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-location-constraint@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.428.0.tgz#a3e46a4d853fb256d6188eae3ed73c276a1bc36d"
+  integrity sha512-2YvAhkdzMITTc2fVIH7FS5Hqa7AuoHBg92W0CzPOiKBkC0D6m5hw8o5Z5RnH/M9ki2eB4dn+7uB6p7Lgs+VFdw==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-logger@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.428.0.tgz#215009964e8997bee9e6a38461e5d6247d4265d0"
+  integrity sha512-1P0V0quL9u2amdNOn6yYT7/ToQUmkLJqCKHPxsRyDB829vBThWndvvH5MkoItj/VgE1zWqMtrzN3xtzD7zx6Qg==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-recursion-detection@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.428.0.tgz#f9491306d0613459cc4fcd7b6d381329a6235148"
+  integrity sha512-xC0OMduCByyRdiQz324RXy4kunnCG4LUJCfvdoegM33Elp9ex0D3fcfO1mUgV8qiLwSennIsSRVXHuhNxE2HZA==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-sdk-s3@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.428.0.tgz#b3546fa0ed22411acd13a6aadbc7dbd23562cffc"
+  integrity sha512-C9hJlzMGlDeVNn91TvC6lsTplnH4hFPM2kiuMha5A/EXPPOg9c5vFH5awL3ubEiIUPwwDu3d583hvsPd6G3qxA==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-arn-parser" "3.310.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-sdk-sts@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.428.0.tgz#c4f5e6496d2fe47908de5f5549c67042398516f7"
+  integrity sha512-Uutl2niYXTnNP8v84v6umWDHD5no7d5/OqkZE1DsmeKR/dje90J5unJWf7MOsqvYm0JGDEWF4lk9xGVyqsw+Aw==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-signing@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.428.0.tgz#ce9f21963bac8c8bb42d84dd2901628aa661b844"
+  integrity sha512-oMSerTPwtsQAR7fIU/G0b0BA30wF+MC4gZSrJjbypF8MK8nPC2yMfKLR8+QavGOGEW7rUMQ0uklThMTTwQEXNQ==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/signature-v4" "^2.0.0"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-middleware" "^2.0.4"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-ssec@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.428.0.tgz#9a0c631401c5c4bf3acaeedd7fed6f808b5f5fd5"
+  integrity sha512-QPKisAErRHFoopmdFhgOmjZPcUM6rvWCtnoEY4Sw9F0aIyK6yCTn+nB5j+3FAPvUvblE22srM6aow8TcGx1gjA==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/middleware-user-agent@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.428.0.tgz#85ac71da101a10adcb1ee0ecc4c5a25a080d2e5c"
+  integrity sha512-+GAhObeHRick2D5jr3YkPckjcggt5v6uUVtEUQW2AdD65cE5PjIvmksv6FuM/mME/9nNA+wufQnHbLI8teLeaw==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-endpoints" "3.428.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/region-config-resolver@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.428.0.tgz#c275998078cbd784febd212e987e546905efafc7"
+  integrity sha512-VqyHZ/Hoz3WrXXMx8cAhFBl8IpjodbRsTjBI117QPq1YRCegxNdGvqmGZnJj8N2Ef9MP1iU30ZWQB+sviDcogA==
+  dependencies:
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-config-provider" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.4"
+    tslib "^2.5.0"
+
+"@aws-sdk/signature-v4-multi-region@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.428.0.tgz#30de84c6391f140e446e1bc1b482270863b098df"
+  integrity sha512-ImuontXK1vEHtxK+qiPVfLTk/+bKSwYqrVkE2/o5rnsqD78/wySzTn5RnkA73Nb+UL4qSd0dkOcuubEee2aUpQ==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/signature-v4" "^2.0.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/token-providers@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.428.0.tgz#9a5935c57f209ab20e5c2be84d1f7cf72743451b"
+  integrity sha512-Jciofr//rB1v1FLxADkXoHOCmYyiv2HVNlOq3z5Zkch9ipItOfD6X7f4G4n+IZzElIFzwe4OKoBtJfcnnfo3Pg==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/middleware-host-header" "3.428.0"
+    "@aws-sdk/middleware-logger" "3.428.0"
+    "@aws-sdk/middleware-recursion-detection" "3.428.0"
+    "@aws-sdk/middleware-user-agent" "3.428.0"
+    "@aws-sdk/types" "3.428.0"
+    "@aws-sdk/util-endpoints" "3.428.0"
+    "@aws-sdk/util-user-agent-browser" "3.428.0"
+    "@aws-sdk/util-user-agent-node" "3.428.0"
+    "@smithy/config-resolver" "^2.0.14"
+    "@smithy/fetch-http-handler" "^2.2.3"
+    "@smithy/hash-node" "^2.0.11"
+    "@smithy/invalid-dependency" "^2.0.11"
+    "@smithy/middleware-content-length" "^2.0.13"
+    "@smithy/middleware-endpoint" "^2.1.0"
+    "@smithy/middleware-retry" "^2.0.16"
+    "@smithy/middleware-serde" "^2.0.11"
+    "@smithy/middleware-stack" "^2.0.5"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/node-http-handler" "^2.1.7"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/shared-ini-file-loader" "^2.0.6"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.15"
+    "@smithy/util-defaults-mode-node" "^2.0.19"
+    "@smithy/util-retry" "^2.0.4"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/types@3.428.0", "@aws-sdk/types@^3.222.0":
   version "3.428.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.428.0.tgz#fcb62a5fc38c4e579dc2b251194483aaad393df0"
   integrity sha512-4T0Ps2spjg3qbWE6ZK13Vd3FnzpfliaiotqjxUK5YhjDrKXeT36HJp46JhDupElQuHtTkpdiJOSYk2lvY2H4IA==
   dependencies:
     "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-arn-parser@3.310.0":
+  version "3.310.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz#861ff8810851be52a320ec9e4786f15b5fc74fba"
+  integrity sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==
+  dependencies:
+    tslib "^2.5.0"
+
+"@aws-sdk/util-endpoints@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.428.0.tgz#99e6b9ad4147a862fcabcdccf8cbab6b4cf815ac"
+  integrity sha512-ToKMhYlUWJ0YrbggpJLZeyZZNDXtQ4NITxqo/oeGltTT9KG4o/LqVY59EveV0f8P32ObDyj9Vh1mnjxeo3DxGw==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.310.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz#b071baf050301adee89051032bd4139bba32cc40"
+  integrity sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==
+  dependencies:
+    tslib "^2.5.0"
+
+"@aws-sdk/util-user-agent-browser@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.428.0.tgz#3dacafe5088e55d3bc70371886030712eeb6a0fa"
+  integrity sha512-qlc2UoGsmCpuh1ErY3VayZuAGl74TWWcLmhhQMkeByFSb6KooBlwOmDpDzJRtgwJoe0KXnyHBO6lzl9iczcozg==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/types" "^2.3.5"
+    bowser "^2.11.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-user-agent-node@3.428.0":
+  version "3.428.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.428.0.tgz#3966016d3592f0ccff4b0123c3b223e1e231279a"
+  integrity sha512-s721C3H8TkNd0usWLPEAy7yW2lEglR8QAYojdQGzE0e0wymc671nZAFePSZFRtmqZiFOSfk0R602L5fDbP3a8Q==
+  dependencies:
+    "@aws-sdk/types" "3.428.0"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.259.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz#3275a6f5eb334f96ca76635b961d3c50259fd9ff"
+  integrity sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/xml-builder@3.310.0":
+  version "3.310.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz#f0236f2103b438d16117e0939a6305ad69b7ff76"
+  integrity sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==
+  dependencies:
     tslib "^2.5.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13":
@@ -976,11 +1567,442 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@smithy/abort-controller@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-2.0.11.tgz#e1d96a2ecbf103d0b075a7456ce3afeeb9f76a87"
+  integrity sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/chunked-blob-reader-native@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.0.tgz#f6d0eeeb5481026b68b054f45540d924c194d558"
+  integrity sha512-HM8V2Rp1y8+1343tkZUKZllFhEQPNmpNdgFAncbTsxkZ18/gqjk23XXv3qGyXWp412f3o43ZZ1UZHVcHrpRnCQ==
+  dependencies:
+    "@smithy/util-base64" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/chunked-blob-reader@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz#c44fe2c780eaf77f9e5381d982ac99a880cce51b"
+  integrity sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/config-resolver@^2.0.14":
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-2.0.14.tgz#16163e14053949f5a717be6f5802a7039e5ff4d1"
+  integrity sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==
+  dependencies:
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-config-provider" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.4"
+    tslib "^2.5.0"
+
+"@smithy/credential-provider-imds@^2.0.0", "@smithy/credential-provider-imds@^2.0.16":
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.16.tgz#07da7ecd43eff92156ddc54f3b5330bbc128d5cd"
+  integrity sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==
+  dependencies:
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/property-provider" "^2.0.12"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-codec@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-2.0.11.tgz#1ba090ea5dbf956e32d3d0d0986ffb0d0af8c57d"
+  integrity sha512-BQCTjxhCYRZIfXapa2LmZSaH8QUBGwMZw7XRN83hrdixbLjIcj+o549zjkedFS07Ve2TlvWUI6BTzP+nv7snBA==
+  dependencies:
+    "@aws-crypto/crc32" "3.0.0"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-serde-browser@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.11.tgz#eb9e9105d04c5dd0c96d5544857fe4e4d9d113a8"
+  integrity sha512-p9IK4uvwT6B3pT1VGlODvcVBfPVikjBFHAcKpvvNF+7lAEI+YiC6d0SROPkpjnvCgVBYyGXa3ciqrWnFze6mwQ==
+  dependencies:
+    "@smithy/eventstream-serde-universal" "^2.0.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-serde-config-resolver@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.11.tgz#f5fda274bc823a5d84a1ab1634ea7f9f4e82d9cb"
+  integrity sha512-vN32E8yExo0Z8L7kXhlU9KRURrhqOpPdLxQMp3MwfMThrjiqbr1Sk5srUXc1ed2Ygl/l0TEN9vwNG0bQHg6AjQ==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-serde-node@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.11.tgz#920e1b6ba6a216a58f519865b8585df61b675f87"
+  integrity sha512-Gjqbpg7UmD+YzkpgNShNcDNZcUpBWIkvX2XCGptz5PoxJU/UQbuF9eSc93ZlIb7j4aGjtFfqk23HUMW8Hopg2Q==
+  dependencies:
+    "@smithy/eventstream-serde-universal" "^2.0.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-serde-universal@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.11.tgz#c86c0d29eae479590826ad61cb28301ec1105ebe"
+  integrity sha512-F8FsxLTbFN4+Esgpo+nNKcEajrgRZJ+pG9c8+MhLM4Odp5ejLHw2GMCXd81cGsgmfcbnzdDEXazPPVzOwj89MQ==
+  dependencies:
+    "@smithy/eventstream-codec" "^2.0.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/fetch-http-handler@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.3.tgz#86445f63dbf09ec331b6199fc2f0f44fec1b1417"
+  integrity sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==
+  dependencies:
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/querystring-builder" "^2.0.11"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-base64" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/hash-blob-browser@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.11.tgz#6bcd0ffc1f68427dff1d8051c893df92a36f3e7e"
+  integrity sha512-/6vq/NiH2EN3mWdwcLdjVohP+VCng+ZA1GnlUdx959egsfgIlLWQvCyjnB2ze9Hr6VHV5XEFLLpLQH2dHA6Sgw==
+  dependencies:
+    "@smithy/chunked-blob-reader" "^2.0.0"
+    "@smithy/chunked-blob-reader-native" "^2.0.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/hash-node@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-2.0.11.tgz#07d73eefa9ab28e4f03461c6ec0532b85792329d"
+  integrity sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-buffer-from" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/hash-stream-node@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-stream-node/-/hash-stream-node-2.0.11.tgz#95c1ef3681d988770acdab863707daf068a851f8"
+  integrity sha512-Jn2yl+Dn0kvwKvSavvR1/BFVYa2wIkaJKWeTH48kno89gqHAJxMh1hrtBN6SJ7F8VhodNZTiNOlQVqCSfLheNQ==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/invalid-dependency@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-2.0.11.tgz#41811da5da9950f52a0491ea532add2b1895349b"
+  integrity sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/is-array-buffer@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz#8fa9b8040651e7ba0b2f6106e636a91354ff7d34"
+  integrity sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/md5-js@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/md5-js/-/md5-js-2.0.11.tgz#0235c22eca4b5af72728f20348af5280bef2f275"
+  integrity sha512-YBIv+e95qeGvQA05ucwstmTeQ/bUzWgU+nO2Ffmif5awu6IzSR0Jfk3XLYh4mdy7f8DCgsn8qA63u7N9Lu0+5A==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/middleware-content-length@^2.0.13":
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-2.0.13.tgz#eb8195510fac8e2d925e43f270f347d8e2ce038b"
+  integrity sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==
+  dependencies:
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/middleware-endpoint@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.1.tgz#6eec29c380a8f0f9cadc9b28bf8b453c5b671985"
+  integrity sha512-YAqGagBvHqDEew4EGz9BrQ7M+f+u7ck9EL4zzYirOhIcXeBS/+q4A5+ObHDDwEp38lD6t88YUtFy3OptqEaDQg==
+  dependencies:
+    "@smithy/middleware-serde" "^2.0.11"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/shared-ini-file-loader" "^2.2.0"
+    "@smithy/types" "^2.3.5"
+    "@smithy/url-parser" "^2.0.11"
+    "@smithy/util-middleware" "^2.0.4"
+    tslib "^2.5.0"
+
+"@smithy/middleware-retry@^2.0.16":
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-2.0.16.tgz#f87401a01317de351df5228e4591961d04663607"
+  integrity sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==
+  dependencies:
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/service-error-classification" "^2.0.4"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-middleware" "^2.0.4"
+    "@smithy/util-retry" "^2.0.4"
+    tslib "^2.5.0"
+    uuid "^8.3.2"
+
+"@smithy/middleware-serde@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-2.0.11.tgz#89c4433b9b4077e2f71f436cd4f97d613e2cf3bd"
+  integrity sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/middleware-stack@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-2.0.5.tgz#43cd8aa7141b23dfbb64dff9ead8a3983d3acc5c"
+  integrity sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/node-config-provider@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-2.1.1.tgz#34c861b95a4e1b66a2dc1d1aecc2bca08466bd5e"
+  integrity sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==
+  dependencies:
+    "@smithy/property-provider" "^2.0.12"
+    "@smithy/shared-ini-file-loader" "^2.2.0"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/node-http-handler@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-2.1.7.tgz#a920e0e40fd04e2ea399cb4f06092fea0a1b66da"
+  integrity sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==
+  dependencies:
+    "@smithy/abort-controller" "^2.0.11"
+    "@smithy/protocol-http" "^3.0.7"
+    "@smithy/querystring-builder" "^2.0.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/property-provider@^2.0.0", "@smithy/property-provider@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-2.0.12.tgz#09391cae6f336300e88128717ee5fb7cff76c5b4"
+  integrity sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/protocol-http@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-3.0.7.tgz#4deec17a27f7cc5d2bea962fcb0cdfbfd311b05c"
+  integrity sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/querystring-builder@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-2.0.11.tgz#7a56bed12474ad46059116d87eb7b81cdba9d7f6"
+  integrity sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-uri-escape" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/querystring-parser@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-2.0.11.tgz#63b7fde68714974c220e386002100ad9b70d91a3"
+  integrity sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/service-error-classification@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-2.0.4.tgz#05c0a30eddbf63fb5f27704757da388aec5d66c2"
+  integrity sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+
+"@smithy/shared-ini-file-loader@^2.0.6", "@smithy/shared-ini-file-loader@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.0.tgz#9e4a90a29fe3f109875c26e6127802ed0953f43d"
+  integrity sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/signature-v4@^2.0.0":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-2.0.11.tgz#e6d9065c7a73fc6f518f0cbc94039aed49307a1c"
+  integrity sha512-EFVU1dT+2s8xi227l1A9O27edT/GNKvyAK6lZnIZ0zhIHq/jSLznvkk15aonGAM1kmhmZBVGpI7Tt0odueZK9A==
+  dependencies:
+    "@smithy/eventstream-codec" "^2.0.11"
+    "@smithy/is-array-buffer" "^2.0.0"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.4"
+    "@smithy/util-uri-escape" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/smithy-client@^2.1.11":
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-2.1.11.tgz#7e27c9969048952703ae493311245d1af62c73b8"
+  integrity sha512-okjMbuBBCTiieK665OFN/ap6u9+Z9z55PMphS5FYCsS6Zfp137Q3qlnt0OgBAnUVnH/mNGyoJV0LBX9gkTWptg==
+  dependencies:
+    "@smithy/middleware-stack" "^2.0.5"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-stream" "^2.0.16"
+    tslib "^2.5.0"
+
 "@smithy/types@^2.3.5":
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-2.3.5.tgz#7684a74d4368f323b478bd9e99e7dc3a6156b5e5"
   integrity sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==
   dependencies:
+    tslib "^2.5.0"
+
+"@smithy/url-parser@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-2.0.11.tgz#19c157f9d47217259e587847101ef6bd83091a5e"
+  integrity sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==
+  dependencies:
+    "@smithy/querystring-parser" "^2.0.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/util-base64@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-2.0.0.tgz#1beeabfb155471d1d41c8d0603be1351f883c444"
+  integrity sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-body-length-browser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz#5447853003b4c73da3bc5f3c5e82c21d592d1650"
+  integrity sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-body-length-node@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz#313a5f7c5017947baf5fa018bfc22628904bbcfa"
+  integrity sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-buffer-from@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz#7eb75d72288b6b3001bc5f75b48b711513091deb"
+  integrity sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-config-provider@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz#4dd6a793605559d94267312fd06d0f58784b4c38"
+  integrity sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-defaults-mode-browser@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.15.tgz#0ab82d6e88dbebcca5e570678790a0160bd2619c"
+  integrity sha512-2raMZOYKSuke7QlDg/HDcxQdrp0zteJ8z+S0B9Rn23J55ZFNK1+IjG4HkN6vo/0u3Xy/JOdJ93ibiBSB8F7kOw==
+  dependencies:
+    "@smithy/property-provider" "^2.0.12"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    bowser "^2.11.0"
+    tslib "^2.5.0"
+
+"@smithy/util-defaults-mode-node@^2.0.19":
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.19.tgz#8996479c76dd68baae65fd863180a802a66fdf5d"
+  integrity sha512-7pScU4jBFADB2MBYKM3zb5onMh6Nn0X3IfaFVLYPyCarTIZDLUtUl1GtruzEUJPmDzP+uGeqOtU589HDY0Ni6g==
+  dependencies:
+    "@smithy/config-resolver" "^2.0.14"
+    "@smithy/credential-provider-imds" "^2.0.16"
+    "@smithy/node-config-provider" "^2.1.1"
+    "@smithy/property-provider" "^2.0.12"
+    "@smithy/smithy-client" "^2.1.11"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/util-hex-encoding@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz#0aa3515acd2b005c6d55675e377080a7c513b59e"
+  integrity sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-middleware@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-2.0.4.tgz#2c406efac04e341c3df6435d71fd9c73e03feb46"
+  integrity sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==
+  dependencies:
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/util-retry@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-2.0.4.tgz#b3ae28e73b4bdec21480005e76f9eeb9d7279e89"
+  integrity sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==
+  dependencies:
+    "@smithy/service-error-classification" "^2.0.4"
+    "@smithy/types" "^2.3.5"
+    tslib "^2.5.0"
+
+"@smithy/util-stream@^2.0.16":
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-2.0.16.tgz#8501e14cfcac70913d2c4c01a8cfbf7fc73bc041"
+  integrity sha512-b5ZSRh1KzUzC7LoJcpfk7+iXGoRr3WylEfmPd4FnBLm90OwxSB9VgK1fDZwicfYxSEvWHdYXgvvjPtenEYBBhw==
+  dependencies:
+    "@smithy/fetch-http-handler" "^2.2.3"
+    "@smithy/node-http-handler" "^2.1.7"
+    "@smithy/types" "^2.3.5"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-buffer-from" "^2.0.0"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-uri-escape@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz#19955b1a0f517a87ae77ac729e0e411963dfda95"
+  integrity sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.0.0.tgz#b4da87566ea7757435e153799df9da717262ad42"
+  integrity sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-waiter@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/util-waiter/-/util-waiter-2.0.11.tgz#1cef055d557675bb187221b510cd666643dc207a"
+  integrity sha512-8SJWUl9O1YhjC77EccgltI3q4XZQp3vp9DGEW6o0OdkUcwqm/H4qOLnMkA2n+NDojuM5Iia2jWoCdbluIiG7TA==
+  dependencies:
+    "@smithy/abort-controller" "^2.0.11"
+    "@smithy/types" "^2.3.5"
     tslib "^2.5.0"
 
 "@szmarczak/http-timer@^5.0.1":
@@ -1636,22 +2658,6 @@ aws-cdk@^2:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1473.0:
-  version "2.1473.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1473.0.tgz#0bd127447055e0457cf2f4e42c57808dfe44a43b"
-  integrity sha512-fl45qeU/Mjhfdocsh38Uw9hkZIec10gMfYDovtWm9/eK8V6zn3jtHUNKPfM2yXCjebmsk3s0FNR21aSv5suzsQ==
-  dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.16.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    util "^0.12.4"
-    uuid "8.0.0"
-    xml2js "0.5.0"
-
 babel-jest@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.5.1.tgz#a1bf8d61928edfefd21da27eb86a695bfd691444"
@@ -1718,10 +2724,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 boxen@^7.0.0:
   version "7.1.1"
@@ -1792,15 +2798,6 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-buffer@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 builtins@^5.0.0:
   version "5.0.1"
@@ -2915,11 +3912,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-events@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
-
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -3005,6 +3997,13 @@ fast-memoize@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
   integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
+fast-xml-parser@4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
+  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
+  dependencies:
+    strnum "^1.0.5"
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -3625,16 +4624,6 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
-ieee754@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ignore-walk@^6.0.0:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-6.0.3.tgz#0fcdb6decaccda35e308a7b0948645dd9523b7bb"
@@ -3725,14 +4714,6 @@ ip@^2.0.0:
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
   integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
 
-is-arguments@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
@@ -3802,13 +4783,6 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
-
-is-generator-function@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
-  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
-  dependencies:
-    has-tostringtag "^1.0.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
@@ -3918,7 +4892,7 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.3, is-typed-array@^1.1.9:
+is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.9:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
   integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
@@ -3942,15 +4916,15 @@ is-yarn-global@^0.4.0:
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.4.1.tgz#b312d902b313f81e4eaf98b6361ba2b45cd694bb"
   integrity sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==
 
-isarray@^1.0.0, isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
-
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4432,11 +5406,6 @@ jju@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
-
-jmespath@0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
-  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -5768,11 +6737,6 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
-
 punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
@@ -5789,11 +6753,6 @@ q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -6101,16 +7060,6 @@ safe-regex-test@^1.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sax@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
-
-sax@>=0.6.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
-  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
 
 saxes@^5.0.1:
   version "5.0.1"
@@ -6546,6 +7495,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -6757,7 +7711,12 @@ tsconfig-paths@^3.14.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.5.0:
+tslib@^1.11.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.1, tslib@^2.5.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -6988,34 +7947,10 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-url@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-util@^0.12.4:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
-
-uuid@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
-  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 uuid@^8.3.2:
   version "8.3.2"
@@ -7121,7 +8056,7 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which-typed-array@^1.1.11, which-typed-array@^1.1.2:
+which-typed-array@^1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
   integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
@@ -7223,14 +8158,6 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
-  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
 xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
@@ -7250,11 +8177,6 @@ xmlbuilder@^15.1.1:
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Lambda with Node 18 no longer packages aws-sdk v2, so we need to switch to v3. We also need to bundle it since Node 16 still comes with v2. To support both 16 and 18, we need to bundle aws-sdk.

BREAKING CHANGE: CDK 2.87.0 and above is required