### PR TITLE
fix: Java bundling stopped working

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -164,7 +164,7 @@ export class BaseDependencyPackager extends Construct implements iam.IGrantable,
         subnetSelection: internalProps.props?.subnetSelection,
         environment: {
           buildImage: this.architecture == lambda.Architecture.X86_64 ?
-            codebuild.LinuxBuildImage.AMAZON_LINUX_2_5 : codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_2_0,
+            codebuild.LinuxBuildImage.AMAZON_LINUX_2_5 : codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
         },
         logging: {
           cloudWatch: {
@@ -197,7 +197,7 @@ export class BaseDependencyPackager extends Construct implements iam.IGrantable,
         ],
         logRetention: RetentionDays.ONE_MONTH,
       });
-      this.provider.node.addDependency(this.project);
+            this.provider.node.addDependency(this.project);
       this.packagesBucket.grantDelete(this.provider);
     } else if (this.type == DependencyPackagerType.LAMBDA) {
       const lambdaProps = {

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "3a503d4db4e69346c332bfe77fce8ce0c794379d3af40b21131b92e270d6c489": {
+    "ca58bd87cb799fc28d4ab0ad7e68f27535125e8e95625d6a331bc473d09c7ae8": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3a503d4db4e69346c332bfe77fce8ce0c794379d3af40b21131b92e270d6c489.json",
+          "objectKey": "ca58bd87cb799fc28d4ab0ad7e68f27535125e8e95625d6a331bc473d09c7ae8.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -7919,9 +7919,9 @@
     },
     "CodeBuildInstallCommands": [
      "echo Installing java-11-amazon-corretto",
-     "yum install -y java-11-amazon-corretto",
-     "alternatives --set java /usr/lib/jvm/java-11-amazon-corretto.*/bin/java",
-     "alternatives --set javac /usr/lib/jvm/java-11-amazon-corretto.*/bin/javac"
+     "yum install -y java-11-amazon-corretto-devel.x86_64 java-11-amazon-corretto-headless.x86_64",
+     "alternatives --set java $(rpm -ql java-11-amazon-corretto-headless.x86_64 | grep bin/java$ | head -n 1)",
+     "alternatives --set javac $(rpm -ql java-11-amazon-corretto-devel.x86_64 | grep bin/javac$ | head -n 1)"
     ],
     "PreinstallCommands": [],
     "Commands": [

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3a503d4db4e69346c332bfe77fce8ce0c794379d3af40b21131b92e270d6c489.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/ca58bd87cb799fc28d4ab0ad7e68f27535125e8e95625d6a331bc473d09c7ae8.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [


### PR DESCRIPTION
Upgrading to Amazon Linux 2023 for CodeBuild changed the package name we need to install for Java. The upgrade was required for Node 18 support.