### PR TITLE
fix: Ruby 2.7 can't be installed

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -18,7 +18,8 @@ export class RubyDependencyPackager extends BaseDependencyPackager {
       runtimeFamily: lambda.RuntimeFamily.RUBY,
       defaultRuntime: lambda.Runtime.RUBY_2_7,
       codeBuildRuntimeInstallCommands: [
-        `RUBY_VERSION=\`rbenv install -l | tr -d ' ' | grep ^${RubyDependencyPackager.runtimeVersion(props)} | sort -Vr | head -n 1\``,
+        'yum install -y perl', // Can't locate FindBin.pm in @INC
+        `RUBY_VERSION=\`rbenv install -L | tr -d ' ' | grep ^${RubyDependencyPackager.runtimeVersion(props)} | sort -Vr | head -n 1\``,
         'echo Installing Ruby ${RUBY_VERSION}',
         'rbenv install -s ${RUBY_VERSION}',
         'rbenv global ${RUBY_VERSION}',

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -235,7 +235,7 @@
         }
       }
     },
-    "4b3460f00aba32fc67e61a0a06f04f4782afcfe959f01533d56443c7b78fa175": {
+    "3ee36a2bccc53d67e3da976b0c29b46bbfd5733bb6c8af315af557f3dcdb9bf5": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4b3460f00aba32fc67e61a0a06f04f4782afcfe959f01533d56443c7b78fa175.json",
+          "objectKey": "3ee36a2bccc53d67e3da976b0c29b46bbfd5733bb6c8af315af557f3dcdb9bf5.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -6848,7 +6848,8 @@
      "Ref": "Ruby27CodeBuildPackagerBucketD708F0AD"
     },
     "CodeBuildInstallCommands": [
-     "RUBY_VERSION=`rbenv install -l | tr -d ' ' | grep ^2.7 | sort -Vr | head -n 1`",
+     "yum install -y perl",
+     "RUBY_VERSION=`rbenv install -L | tr -d ' ' | grep ^2.7 | sort -Vr | head -n 1`",
      "echo Installing Ruby ${RUBY_VERSION}",
      "rbenv install -s ${RUBY_VERSION}",
      "rbenv global ${RUBY_VERSION}"
@@ -7294,7 +7295,8 @@
      "Ref": "Ruby27LambdaPackagerBucket8E60AB86"
     },
     "CodeBuildInstallCommands": [
-     "RUBY_VERSION=`rbenv install -l | tr -d ' ' | grep ^2.7 | sort -Vr | head -n 1`",
+     "yum install -y perl",
+     "RUBY_VERSION=`rbenv install -L | tr -d ' ' | grep ^2.7 | sort -Vr | head -n 1`",
      "echo Installing Ruby ${RUBY_VERSION}",
      "rbenv install -s ${RUBY_VERSION}",
      "rbenv global ${RUBY_VERSION}"

--- a/test/default.integ.snapshot/manifest.json
+++ b/test/default.integ.snapshot/manifest.json
@@ -17,7 +17,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4b3460f00aba32fc67e61a0a06f04f4782afcfe959f01533d56443c7b78fa175.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/3ee36a2bccc53d67e3da976b0c29b46bbfd5733bb6c8af315af557f3dcdb9bf5.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [


### PR DESCRIPTION
rbenv stopped listing 2.7 by default and Amazon Linux 2023 was missing Perl as a dependency.