### PR TITLE
chore: Fix snapshot updater

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -80,7 +80,7 @@ jobs:
             ------
 
             *Automatically created by projen via the "upgrade-snapshot" workflow*
-          branch: ${{ github.event.workflow_run.head_branch }}/upgrade-snapshot
+          branch: ${{ github.event.workflow_run.head_branch }}-upgrade-snapshot
           title: "chore(deps): update snapshot for dependencies upgrade"
           body: |-
             Update snapshot. See details in [workflow run].


### PR DESCRIPTION
Branch name can't have two slashes. No easy way to get PR number for better branch name.