### PR TITLE
fix: Python packaging error message was missing

### DIFF
--- a/src/package-python.lambda.py
+++ b/src/package-python.lambda.py
@@ -18,7 +18,9 @@ s3 = boto3.client("s3")
 
 
 class CommandError(Exception):
-    pass
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
 
 
 def cancel_on_timeout(event, context):

--- a/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.assets.json
@@ -105,15 +105,15 @@
         }
       }
     },
-    "190116602f67fcba43a33629264da3211c4f9cc2ae688bdf0ee6d8c7e4ec48fd": {
+    "ef31fc89d7ced5ea0cff316469a82711784a006d3ae7a037f2b2422969eafc2e": {
       "source": {
-        "path": "asset.190116602f67fcba43a33629264da3211c4f9cc2ae688bdf0ee6d8c7e4ec48fd.lambda",
+        "path": "asset.ef31fc89d7ced5ea0cff316469a82711784a006d3ae7a037f2b2422969eafc2e.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "190116602f67fcba43a33629264da3211c4f9cc2ae688bdf0ee6d8c7e4ec48fd.zip",
+          "objectKey": "ef31fc89d7ced5ea0cff316469a82711784a006d3ae7a037f2b2422969eafc2e.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -235,7 +235,7 @@
         }
       }
     },
-    "452465eccdd313e71bc8716f12e024973e380b061470c9b4392f42d9419f649f": {
+    "332ea9ae34086dc09135fb22955c4ab0465933a66dd91205e817ec23a5a6c884": {
       "source": {
         "path": "Turbo-Layer-Test.template.json",
         "packaging": "file"
@@ -243,7 +243,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "452465eccdd313e71bc8716f12e024973e380b061470c9b4392f42d9419f649f.json",
+          "objectKey": "332ea9ae34086dc09135fb22955c4ab0465933a66dd91205e817ec23a5a6c884.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/default.integ.snapshot/Turbo-Layer-Test.template.json
+++ b/test/default.integ.snapshot/Turbo-Layer-Test.template.json
@@ -2629,7 +2629,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "190116602f67fcba43a33629264da3211c4f9cc2ae688bdf0ee6d8c7e4ec48fd.zip"
+     "S3Key": "ef31fc89d7ced5ea0cff316469a82711784a006d3ae7a037f2b2422969eafc2e.zip"
     },
     "Role": {
      "Fn::GetAtt": [
@@ -4741,7 +4741,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "190116602f67fcba43a33629264da3211c4f9cc2ae688bdf0ee6d8c7e4ec48fd.zip"
+     "S3Key": "ef31fc89d7ced5ea0cff316469a82711784a006d3ae7a037f2b2422969eafc2e.zip"
     },
     "Role": {
      "Fn::GetAtt": [


### PR DESCRIPTION
Instead of returning the actual error message to the custom resource, we returned:

```
Internal error: 'CommandError' object has no attribute 'message'
```

Fixes #115